### PR TITLE
[hotfix] bug in filtered list 

### DIFF
--- a/JWords/iOSView/items/WordCell.swift
+++ b/JWords/iOSView/items/WordCell.swift
@@ -103,7 +103,7 @@ struct WordCell: View {
                     isFront.toggle()
                 })
                 .onLongPressGesture {
-                    // FIXME: this is about view!!! not about logic
+                    
                 }
             }
         }


### PR DESCRIPTION
# 버그
맨 위 것을 뒤집고 나서 성공 처리하면 아래 단어가 맨 위로 올라오는데 이때 뒤집힌 상태로 올라옴

![필터링 뒤집기 버그](https://user-images.githubusercontent.com/70995840/183538532-9cba87d2-8295-4a11-becc-a16d962970a3.gif)

# 해결
![필터링 뒤집기 버그 해결](https://user-images.githubusercontent.com/70995840/183545897-4ce551ff-4042-4919-8f6c-8f54be4122d4.gif)
event에 id도 같이 전달해서 동일하면 isFront가 되도록 했다. (전부 뒤집을 때는 nil)
rendering 되는 타이밍이 모든 데이터가 변하기 전에 모든 동작을 하고 되는 것 같다.
```swift
private func handleEvent(_ event: Event) {
    guard let event = event as? StudyViewEvent else { return }
    switch event {
    case .toFront(let id):
        guard let id = id else { isFront = true; return }
        if id == viewModel.word.id { isFront = true }
    }
}
```
# 버그의 버그;;;
이게 그냥 뒤집히는게 문제인데 cell에서는 아래가 어떻게 되어 있는지 모르니까 그대로 이어서 할 수가 없음
![필터링 뒤집기 버그 해결의 버그](https://user-images.githubusercontent.com/70995840/183546046-3b02df6b-9445-4243-90ee-dd388d605573.gif)
## 일단은...
isFront를 StudyView에서 관리하도록 하고 (Word를 한단계 감싸는 구조체을 만들어서) 일단은 급한 기능부터 개발