### PR TITLE
[Feature] add Kanji

### DIFF
--- a/JWords.xcodeproj/project.pbxproj
+++ b/JWords.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		5A67DC312869529700AC156C /* MacHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A67DC302869529700AC156C /* MacHomeView.swift */; };
 		5A67DC332869565A00AC156C /* MacAddBookView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A67DC322869565A00AC156C /* MacAddBookView.swift */; };
 		5A67DC352869566600AC156C /* MacAddWordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A67DC342869566600AC156C /* MacAddWordView.swift */; };
+		5A98288E28A22FB5006875F6 /* WordDisplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A98288D28A22FB5006875F6 /* WordDisplay.swift */; };
 		5ACE0A712869986F00A57660 /* WordService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ACE0A702869986F00A57660 /* WordService.swift */; };
 		5ACE0A73286998F800A57660 /* Collections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ACE0A72286998F800A57660 /* Collections.swift */; };
 		5ACE0A7628699BAD00A57660 /* WordBook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ACE0A7528699BAD00A57660 /* WordBook.swift */; };
@@ -115,6 +116,7 @@
 		5A67DC302869529700AC156C /* MacHomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacHomeView.swift; sourceTree = "<group>"; };
 		5A67DC322869565A00AC156C /* MacAddBookView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacAddBookView.swift; sourceTree = "<group>"; };
 		5A67DC342869566600AC156C /* MacAddWordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacAddWordView.swift; sourceTree = "<group>"; };
+		5A98288D28A22FB5006875F6 /* WordDisplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordDisplay.swift; sourceTree = "<group>"; };
 		5ACE0A702869986F00A57660 /* WordService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordService.swift; sourceTree = "<group>"; };
 		5ACE0A72286998F800A57660 /* Collections.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Collections.swift; sourceTree = "<group>"; };
 		5ACE0A7528699BAD00A57660 /* WordBook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordBook.swift; sourceTree = "<group>"; };
@@ -336,6 +338,7 @@
 			isa = PBXGroup;
 			children = (
 				5ACE0A7528699BAD00A57660 /* WordBook.swift */,
+				5A98288D28A22FB5006875F6 /* WordDisplay.swift */,
 				5ACE0A7728699BB400A57660 /* Word.swift */,
 				5AD8070A28A0EDE300ADB6F7 /* Events.swift */,
 			);
@@ -539,6 +542,7 @@
 				5A5FF62F286A8F69000150A7 /* ImageUploader.swift in Sources */,
 				5A67DC20286942FE00AC156C /* HomeView.swift in Sources */,
 				5A67DC312869529700AC156C /* MacHomeView.swift in Sources */,
+				5A98288E28A22FB5006875F6 /* WordDisplay.swift in Sources */,
 				5AD8070B28A0EDE300ADB6F7 /* Events.swift in Sources */,
 				5ACE0A7628699BAD00A57660 /* WordBook.swift in Sources */,
 				5A67DC27286944FF00AC156C /* Size.swift in Sources */,

--- a/JWords.xcodeproj/project.pbxproj
+++ b/JWords.xcodeproj/project.pbxproj
@@ -28,7 +28,7 @@
 		06CEF28E2866F86700A620CC /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = 06CEF28D2866F86700A620CC /* FirebaseFirestore */; };
 		06CEF2902866F86700A620CC /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 06CEF28F2866F86700A620CC /* FirebaseFirestoreSwift */; };
 		06CEF2922866F86700A620CC /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 06CEF2912866F86700A620CC /* FirebaseStorage */; };
-		5A1FADFB28A1FC87000ACBD2 /* WordDataReorganizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1FADFA28A1FC87000ACBD2 /* WordDataReorganizer.swift */; };
+		5A1FADFB28A1FC87000ACBD2 /* DataResettingScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1FADFA28A1FC87000ACBD2 /* DataResettingScript.swift */; };
 		5A5328C3286C126C0080D500 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 5A5328C2286C126C0080D500 /* Kingfisher */; };
 		5A5FF62F286A8F69000150A7 /* ImageUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A5FF62E286A8F68000150A7 /* ImageUploader.swift */; };
 		5A5FF632286AD79E000150A7 /* ImageCompressor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A5FF631286AD79E000150A7 /* ImageCompressor.swift */; };
@@ -103,7 +103,7 @@
 		06CEF2752866F32700A620CC /* JWordsAcceptanceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = JWordsAcceptanceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		06CEF2772866F32700A620CC /* JWordsAcceptanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWordsAcceptanceTests.swift; sourceTree = "<group>"; };
 		06CEF27E2866F38500A620CC /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
-		5A1FADFA28A1FC87000ACBD2 /* WordDataReorganizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordDataReorganizer.swift; sourceTree = "<group>"; };
+		5A1FADFA28A1FC87000ACBD2 /* DataResettingScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataResettingScript.swift; sourceTree = "<group>"; };
 		5A5FF62E286A8F68000150A7 /* ImageUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUploader.swift; sourceTree = "<group>"; };
 		5A5FF631286AD79E000150A7 /* ImageCompressor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCompressor.swift; sourceTree = "<group>"; };
 		5A67DC1B2869426500AC156C /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
@@ -326,7 +326,7 @@
 			isa = PBXGroup;
 			children = (
 				5ACE0A702869986F00A57660 /* WordService.swift */,
-				5A1FADFA28A1FC87000ACBD2 /* WordDataReorganizer.swift */,
+				5A1FADFA28A1FC87000ACBD2 /* DataResettingScript.swift */,
 				5A5FF62E286A8F68000150A7 /* ImageUploader.swift */,
 			);
 			path = DataService;
@@ -542,7 +542,7 @@
 				5AD8070B28A0EDE300ADB6F7 /* Events.swift in Sources */,
 				5ACE0A7628699BAD00A57660 /* WordBook.swift in Sources */,
 				5A67DC27286944FF00AC156C /* Size.swift in Sources */,
-				5A1FADFB28A1FC87000ACBD2 /* WordDataReorganizer.swift in Sources */,
+				5A1FADFB28A1FC87000ACBD2 /* DataResettingScript.swift in Sources */,
 				5ACE0A73286998F800A57660 /* Collections.swift in Sources */,
 				5A67DC2D2869470C00AC156C /* WordCell.swift in Sources */,
 				06CEF2492866F1C800A620CC /* ContentView.swift in Sources */,

--- a/JWords.xcodeproj/project.pbxproj
+++ b/JWords.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		06CEF28E2866F86700A620CC /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = 06CEF28D2866F86700A620CC /* FirebaseFirestore */; };
 		06CEF2902866F86700A620CC /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 06CEF28F2866F86700A620CC /* FirebaseFirestoreSwift */; };
 		06CEF2922866F86700A620CC /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 06CEF2912866F86700A620CC /* FirebaseStorage */; };
+		5A1FADFB28A1FC87000ACBD2 /* WordDataReorganizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1FADFA28A1FC87000ACBD2 /* WordDataReorganizer.swift */; };
 		5A5328C3286C126C0080D500 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 5A5328C2286C126C0080D500 /* Kingfisher */; };
 		5A5FF62F286A8F69000150A7 /* ImageUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A5FF62E286A8F68000150A7 /* ImageUploader.swift */; };
 		5A5FF632286AD79E000150A7 /* ImageCompressor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A5FF631286AD79E000150A7 /* ImageCompressor.swift */; };
@@ -102,6 +103,7 @@
 		06CEF2752866F32700A620CC /* JWordsAcceptanceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = JWordsAcceptanceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		06CEF2772866F32700A620CC /* JWordsAcceptanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWordsAcceptanceTests.swift; sourceTree = "<group>"; };
 		06CEF27E2866F38500A620CC /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		5A1FADFA28A1FC87000ACBD2 /* WordDataReorganizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordDataReorganizer.swift; sourceTree = "<group>"; };
 		5A5FF62E286A8F68000150A7 /* ImageUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUploader.swift; sourceTree = "<group>"; };
 		5A5FF631286AD79E000150A7 /* ImageCompressor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCompressor.swift; sourceTree = "<group>"; };
 		5A67DC1B2869426500AC156C /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
@@ -324,6 +326,7 @@
 			isa = PBXGroup;
 			children = (
 				5ACE0A702869986F00A57660 /* WordService.swift */,
+				5A1FADFA28A1FC87000ACBD2 /* WordDataReorganizer.swift */,
 				5A5FF62E286A8F68000150A7 /* ImageUploader.swift */,
 			);
 			path = DataService;
@@ -539,6 +542,7 @@
 				5AD8070B28A0EDE300ADB6F7 /* Events.swift in Sources */,
 				5ACE0A7628699BAD00A57660 /* WordBook.swift in Sources */,
 				5A67DC27286944FF00AC156C /* Size.swift in Sources */,
+				5A1FADFB28A1FC87000ACBD2 /* WordDataReorganizer.swift in Sources */,
 				5ACE0A73286998F800A57660 /* Collections.swift in Sources */,
 				5A67DC2D2869470C00AC156C /* WordCell.swift in Sources */,
 				06CEF2492866F1C800A620CC /* ContentView.swift in Sources */,

--- a/JWords/Constants/Collections.swift
+++ b/JWords/Constants/Collections.swift
@@ -9,7 +9,8 @@ import Firebase
 
 extension Constants {
     enum Collections {
-        static let wordBooks = Firestore.firestore()
+        static let wordBooks =
+            Firestore.firestore()
             .collection("develop")
             .document("data")
             .collection("wordBooks")

--- a/JWords/Constants/Collections.swift
+++ b/JWords/Constants/Collections.swift
@@ -9,7 +9,17 @@ import Firebase
 
 extension Constants {
     enum Collections {
-        static let wordBooks = Firestore.firestore().collection("books")
-        static func word(_ bookID: String) -> CollectionReference { Firestore.firestore().collection("books").document(bookID).collection("words") }
+        static let wordBooks = Firestore.firestore()
+            .collection("develop")
+            .document("data")
+            .collection("wordBooks")
+        static func word(_ bookID: String) -> CollectionReference {
+            Firestore.firestore()
+            .collection("develop")
+            .document("data")
+            .collection("wordBooks")
+            .document(bookID)
+            .collection("words")
+        }
     }
 }

--- a/JWords/DataService/DataResettingScript.swift
+++ b/JWords/DataService/DataResettingScript.swift
@@ -5,69 +5,69 @@
 //  Created by Jong Won Moon on 2022/08/09.
 //
 
-import Firebase
-
-class DataResettingScript {
-    // 전체 데이터를 새로 작성하는 함수
-    static func resetBookData() {
-        // 기존의 단어장의 데이터를 동일하게 새로운 단어장을 만든다.
-        WordService.getWordBooks { wordBooks, _ in
-            guard let wordBooks = wordBooks else { return }
-            for wordBook in wordBooks {
-                let data: [String : Any] = [
-                    "title": wordBook.title,
-                    "timestamp": wordBook.timestamp]
-                Firestore.firestore()
-                    .collection("develop")
-                    .document("data")
-                    .collection("wordBooks")
-                    .addDocument(data: data) { _ in
-                        // 새로 생긴 단어장을 전부 fetch 해와서
-                        getNewWordBooks(wordBook: wordBook) { wordBooks in
-                            // 기존의 단어장과 이름이 일치하는 곳에 새로 단어 저장
-                            guard let oldID = wordBook.id else { return }
-                            let newId = wordBooks.first(where: { $0.title == wordBook.title })!.id!
-                            resetWordData(oldID: oldID, newID: newId)
-                        }
-                    }
-            }
-        }
-    }
-    
-    // 새로운 단어장을 모두 가져온다
-    private static func getNewWordBooks(wordBook: WordBook, completion: @escaping ([WordBook]) -> Void) {
-        Firestore.firestore()
-            .collection("develop")
-            .document("data")
-            .collection("wordBooks")
-            .getDocuments { snapshot, _ in
-                guard let documents = snapshot?.documents else { return }
-                let wordBooks = documents.compactMap({ try? $0.data(as: WordBook.self) })
-                completion(wordBooks)
-            }
-    }
-    
-    // 기존 단어장의 단어장을 가져와서 새로운 단어장에 쓴다.
-    private static func resetWordData(oldID: String, newID: String) {
-        WordService.getWords(wordBookID: oldID) { words, _ in
-            guard let words = words else { return }
-            for word in words {
-                let data: [String : Any] = ["timestamp": word.timestamp,
-                                            "meaningText": word.frontText,
-                                            "meaningImageURL": word.frontImageURL,
-                                            "ganaText": word.backText,
-                                            "ganaImageURL": word.backImageURL,
-                                            "kanjiText": "",
-                                            "kanjiImageURL": "",
-                                            "studyState": word.studyState.rawValue]
-                Firestore.firestore()
-                    .collection("develop")
-                    .document("data")
-                    .collection("wordBooks")
-                    .document(newID)
-                    .collection("words")
-                    .addDocument(data: data)
-            }
-        }
-    }
-}
+//import Firebase
+//
+//class DataResettingScript {
+//    // 전체 데이터를 새로 작성하는 함수
+//    static func resetBookData() {
+//        // 기존의 단어장의 데이터를 동일하게 새로운 단어장을 만든다.
+//        WordService.getWordBooks { wordBooks, _ in
+//            guard let wordBooks = wordBooks else { return }
+//            for wordBook in wordBooks {
+//                let data: [String : Any] = [
+//                    "title": wordBook.title,
+//                    "timestamp": wordBook.timestamp]
+//                Firestore.firestore()
+//                    .collection("develop")
+//                    .document("data")
+//                    .collection("wordBooks")
+//                    .addDocument(data: data) { _ in
+//                        // 새로 생긴 단어장을 전부 fetch 해와서
+//                        getNewWordBooks(wordBook: wordBook) { wordBooks in
+//                            // 기존의 단어장과 이름이 일치하는 곳에 새로 단어 저장
+//                            guard let oldID = wordBook.id else { return }
+//                            let newId = wordBooks.first(where: { $0.title == wordBook.title })!.id!
+//                            resetWordData(oldID: oldID, newID: newId)
+//                        }
+//                    }
+//            }
+//        }
+//    }
+//    
+//    // 새로운 단어장을 모두 가져온다
+//    private static func getNewWordBooks(wordBook: WordBook, completion: @escaping ([WordBook]) -> Void) {
+//        Firestore.firestore()
+//            .collection("develop")
+//            .document("data")
+//            .collection("wordBooks")
+//            .getDocuments { snapshot, _ in
+//                guard let documents = snapshot?.documents else { return }
+//                let wordBooks = documents.compactMap({ try? $0.data(as: WordBook.self) })
+//                completion(wordBooks)
+//            }
+//    }
+//    
+//    // 기존 단어장의 단어장을 가져와서 새로운 단어장에 쓴다.
+//    private static func resetWordData(oldID: String, newID: String) {
+//        WordService.getWords(wordBookID: oldID) { words, _ in
+//            guard let words = words else { return }
+//            for word in words {
+//                let data: [String : Any] = ["timestamp": word.timestamp,
+//                                            "meaningText": word.frontText,
+//                                            "meaningImageURL": word.frontImageURL,
+//                                            "ganaText": word.backText,
+//                                            "ganaImageURL": word.backImageURL,
+//                                            "kanjiText": "",
+//                                            "kanjiImageURL": "",
+//                                            "studyState": word.studyState.rawValue]
+//                Firestore.firestore()
+//                    .collection("develop")
+//                    .document("data")
+//                    .collection("wordBooks")
+//                    .document(newID)
+//                    .collection("words")
+//                    .addDocument(data: data)
+//            }
+//        }
+//    }
+//}

--- a/JWords/DataService/DataResettingScript.swift
+++ b/JWords/DataService/DataResettingScript.swift
@@ -1,5 +1,5 @@
 //
-//  WordDataReorganizer.swift
+//  DataResettingScript.swift
 //  JWords
 //
 //  Created by Jong Won Moon on 2022/08/09.

--- a/JWords/DataService/WordDataReorganizer.swift
+++ b/JWords/DataService/WordDataReorganizer.swift
@@ -1,0 +1,73 @@
+//
+//  WordDataReorganizer.swift
+//  JWords
+//
+//  Created by Jong Won Moon on 2022/08/09.
+//
+
+import Firebase
+
+class DataResettingScript {
+    // 전체 데이터를 새로 작성하는 함수
+    static func resetBookData() {
+        // 기존의 단어장의 데이터를 동일하게 새로운 단어장을 만든다.
+        WordService.getWordBooks { wordBooks, _ in
+            guard let wordBooks = wordBooks else { return }
+            for wordBook in wordBooks {
+                let data: [String : Any] = [
+                    "title": wordBook.title,
+                    "timestamp": wordBook.timestamp]
+                Firestore.firestore()
+                    .collection("develop")
+                    .document("data")
+                    .collection("wordBooks")
+                    .addDocument(data: data) { _ in
+                        // 새로 생긴 단어장을 전부 fetch 해와서
+                        getNewWordBooks(wordBook: wordBook) { wordBooks in
+                            // 기존의 단어장과 이름이 일치하는 곳에 새로 단어 저장
+                            guard let oldID = wordBook.id else { return }
+                            let newId = wordBooks.first(where: { $0.title == wordBook.title })!.id!
+                            resetWordData(oldID: oldID, newID: newId)
+                        }
+                    }
+            }
+        }
+    }
+    
+    // 새로운 단어장을 모두 가져온다
+    private static func getNewWordBooks(wordBook: WordBook, completion: @escaping ([WordBook]) -> Void) {
+        Firestore.firestore()
+            .collection("develop")
+            .document("data")
+            .collection("wordBooks")
+            .getDocuments { snapshot, _ in
+                guard let documents = snapshot?.documents else { return }
+                let wordBooks = documents.compactMap({ try? $0.data(as: WordBook.self) })
+                completion(wordBooks)
+            }
+    }
+    
+    // 기존 단어장의 단어장을 가져와서 새로운 단어장에 쓴다.
+    private static func resetWordData(oldID: String, newID: String) {
+        WordService.getWords(wordBookID: oldID) { words, _ in
+            guard let words = words else { return }
+            for word in words {
+                let data: [String : Any] = ["timestamp": word.timestamp,
+                                            "meaningText": word.frontText,
+                                            "meaningImageURL": word.frontImageURL,
+                                            "ganaText": word.backText,
+                                            "ganaImageURL": word.backImageURL,
+                                            "kanjiText": "",
+                                            "kanjiImageURL": "",
+                                            "studyState": word.studyState.rawValue]
+                Firestore.firestore()
+                    .collection("develop")
+                    .document("data")
+                    .collection("wordBooks")
+                    .document(newID)
+                    .collection("words")
+                    .addDocument(data: data)
+            }
+        }
+    }
+}

--- a/JWords/DataService/WordService.swift
+++ b/JWords/DataService/WordService.swift
@@ -41,27 +41,36 @@ class WordService {
     
     static func saveWord(wordInput: WordInput, wordBookID: String, completionHandler: FireStoreCompletion) {
         let group = DispatchGroup()
-        var frontImageURL = ""
-        var backImageURL = ""
+        var meaningImageURL = ""
+        var ganaImageURL = ""
+        var kanjiImageURL = ""
         
-        if let frontImage = wordInput.frontImage {
-            ImageUploader.uploadImage(image: frontImage, group: group) { url in
-                frontImageURL = url
+        if let meaningImage = wordInput.meaningImage {
+            ImageUploader.uploadImage(image: meaningImage, group: group) { url in
+                meaningImageURL = url
             }
         }
         
-        if let backImage = wordInput.backImage {
-            ImageUploader.uploadImage(image: backImage, group: group) { url in
-                backImageURL = url
+        if let ganaImage = wordInput.ganaImage {
+            ImageUploader.uploadImage(image: ganaImage, group: group) { url in
+                ganaImageURL = url
+            }
+        }
+        
+        if let kanjiImage = wordInput.kanjiImage {
+            ImageUploader.uploadImage(image: kanjiImage, group: group) { url in
+                kanjiImageURL = url
             }
         }
         
         group.notify(queue: .global()) {
             let data: [String : Any] = ["timestamp": Timestamp(date: Date()),
-                                        "frontText": wordInput.frontText,
-                                        "frontImageURL": frontImageURL,
-                                        "backText": wordInput.backText,
-                                        "backImageURL": backImageURL,
+                                        "meaningText": wordInput.meaningText,
+                                        "meaningImageURL": meaningImageURL,
+                                        "ganaText": wordInput.ganaText,
+                                        "ganaImageURL": ganaImageURL,
+                                        "kanjiText": wordInput.kanjiText,
+                                        "kanjiImageURL": kanjiImageURL,
                                         "studyState": wordInput.studyState.rawValue]
             Constants.Collections.word(wordBookID).addDocument(data: data, completion: completionHandler)
         }
@@ -73,8 +82,8 @@ class WordService {
         }
     }
     
-    static func checkIfOverlap(wordBookID: String, frontText: String, completionHandler: @escaping ((Bool?, Error?) -> Void)) {
-        Constants.Collections.word(wordBookID).whereField("frontText", isEqualTo: frontText).getDocuments { snapshot, error in
+    static func checkIfOverlap(wordBookID: String, meaningText: String, completionHandler: @escaping ((Bool?, Error?) -> Void)) {
+        Constants.Collections.word(wordBookID).whereField("meaningText", isEqualTo: meaningText).getDocuments { snapshot, error in
             if let error = error {
                 completionHandler(nil, error)
                 return

--- a/JWords/Model/Events.swift
+++ b/JWords/Model/Events.swift
@@ -10,8 +10,3 @@ protocol Event {}
 enum CellEvent: Event {
     case studyStateUpdate(id: String?, state: StudyState)
 }
-
-enum StudyViewEvent: Event {
-    // 모든 단어가 앞면이 되어야 하면 nil
-    case toFront(id: String?)
-}

--- a/JWords/Model/Word.swift
+++ b/JWords/Model/Word.swift
@@ -32,10 +32,6 @@ struct Word: Identifiable, Codable, Hashable{
     var kanjiImageURL: String = ""
     var studyState: StudyState
     let timestamp: Timestamp
-
-    var hasImage: Bool {
-        return !meaningImageURL.isEmpty || !ganaImageURL.isEmpty || !kanjiImageURL.isEmpty
-    }
 }
 
 struct WordInput {

--- a/JWords/Model/Word.swift
+++ b/JWords/Model/Word.swift
@@ -24,15 +24,17 @@ enum StudyState: Int, Codable {
 
 struct Word: Identifiable, Codable, Hashable{
     @DocumentID var id: String?
-    var frontText: String = ""
-    var frontImageURL: String = ""
-    var backText: String = ""
-    var backImageURL: String = ""
+    var meaningText: String = ""
+    var meaningImageURL: String = ""
+    var ganaText: String = ""
+    var ganaImageURL: String = ""
+    var kanjiText: String = ""
+    var kanjiImageURL: String = ""
     var studyState: StudyState
     let timestamp: Timestamp
-    
+
     var hasImage: Bool {
-        return !frontImageURL.isEmpty || !backImageURL.isEmpty
+        return !meaningImageURL.isEmpty || !ganaImageURL.isEmpty || !kanjiImageURL.isEmpty
     }
 }
 

--- a/JWords/Model/Word.swift
+++ b/JWords/Model/Word.swift
@@ -39,10 +39,12 @@ struct Word: Identifiable, Codable, Hashable{
 }
 
 struct WordInput {
-    let frontText: String
-    let frontImage: InputImageType?
-    let backText: String
-    let backImage: InputImageType?
+    let meaningText: String
+    let meaningImage: InputImageType?
+    let ganaText: String
+    let ganaImage: InputImageType?
+    let kanjiText: String
+    let kanjiImage: InputImageType?
     let studyState: StudyState = .undefined
     let timestamp: Timestamp = Timestamp(date: Date())
 }

--- a/JWords/Model/WordDisplay.swift
+++ b/JWords/Model/WordDisplay.swift
@@ -1,0 +1,56 @@
+//
+//  WordDisplay.swift
+//  JWords
+//
+//  Created by Jong Won Moon on 2022/08/09.
+//
+
+import Foundation
+
+enum FrontType {
+    case meaning
+    case kanji
+}
+
+struct WordDisplay {
+    let wordBook: WordBook
+    var word: Word
+    var frontType: FrontType
+    var isFront: Bool = true
+    
+    var frontText: String {
+        switch frontType {
+        case .meaning:
+            return word.meaningText
+        case .kanji:
+            return word.kanjiText
+        }
+    }
+    
+    var frontImageURL: String {
+        switch frontType {
+        case .meaning:
+            return word.meaningImageURL
+        case .kanji:
+            return word.kanjiImageURL
+        }
+    }
+    
+    var backText: String {
+        switch frontType {
+        case .meaning:
+            return "\(word.ganaText)\n\(word.kanjiText)"
+        case .kanji:
+            return "\(word.ganaText)\n\(word.meaningText)"
+        }
+    }
+    
+    var backImages: [String] {
+        switch frontType {
+        case .meaning:
+            return [word.kanjiImageURL, word.ganaImageURL]
+        case .kanji:
+            return [word.ganaImageURL, word.meaningImageURL]
+        }
+    }
+}

--- a/JWords/Model/WordDisplay.swift
+++ b/JWords/Model/WordDisplay.swift
@@ -10,6 +10,15 @@ import Foundation
 enum FrontType {
     case meaning
     case kanji
+    
+    var toggleButtonTitle: String {
+        switch self {
+        case .meaning:
+            return "漢"
+        case .kanji:
+            return "한"
+        }
+    }
 }
 
 struct WordDisplay {

--- a/JWords/Model/WordDisplay.swift
+++ b/JWords/Model/WordDisplay.swift
@@ -27,30 +27,36 @@ struct WordDisplay {
         }
     }
     
-    var frontImageURL: String {
+    var frontImageURLs: [String] {
         switch frontType {
         case .meaning:
-            return word.meaningImageURL
+            return [word.meaningImageURL].filter { $0.isEmpty }
         case .kanji:
-            return word.kanjiImageURL
+            return [word.kanjiImageURL].filter { $0.isEmpty }
         }
     }
     
     var backText: String {
         switch frontType {
         case .meaning:
-            return "\(word.ganaText)\n\(word.kanjiText)"
+            let changeLine = (!word.ganaText.isEmpty && !word.kanjiText.isEmpty) ? "\n" : ""
+            return "\(word.ganaText)\(changeLine)\(word.kanjiText)"
         case .kanji:
-            return "\(word.ganaText)\n\(word.meaningText)"
+            let changeLine = (!word.ganaText.isEmpty && !word.meaningText.isEmpty) ? "\n" : ""
+            return "\(word.ganaText)\(changeLine)\(word.meaningText)"
         }
     }
     
     var backImages: [String] {
         switch frontType {
         case .meaning:
-            return [word.kanjiImageURL, word.ganaImageURL]
+            return [word.kanjiImageURL, word.ganaImageURL].filter { $0.isEmpty }
         case .kanji:
-            return [word.ganaImageURL, word.meaningImageURL]
+            return [word.ganaImageURL, word.meaningImageURL].filter { $0.isEmpty }
         }
+    }
+    
+    var hasImage: Bool {
+        return !word.meaningImageURL.isEmpty || !word.ganaImageURL.isEmpty || !word.kanjiImageURL.isEmpty
     }
 }

--- a/JWords/iOSView/Study/StudyView.swift
+++ b/JWords/iOSView/Study/StudyView.swift
@@ -32,9 +32,9 @@ struct StudyView: View {
     var body: some View {
         ScrollView {
             LazyVStack(spacing: 32) {
-                ForEach(0..<viewModel.words.count, id: \.self) { index in
-                    WordCell(word: viewModel.words[index], eventPublisher: viewModel.eventPublisher)
-                        .frame(width: deviceWidth * 0.9, height: viewModel.words[index].hasImage ? 200 : 100)
+                ForEach(0..<viewModel.displays.count, id: \.self) { index in
+                    WordCell(wordDisplay: $viewModel.displays[index], eventPublisher: viewModel.eventPublisher)
+                        .frame(width: deviceWidth * 0.9, height: viewModel.displays[index].hasImage ? 200 : 100)
                 }
             }
         }
@@ -74,9 +74,10 @@ struct StudyView: View {
 extension StudyView {
     final class ViewModel: ObservableObject {
         let wordBook: WordBook
-        private var rawWords: [Word] = []
-        @Published var words: [Word] = []
+        private var words: [Word] = []
+        @Published var displays: [WordDisplay] = []
         @Published private(set) var studyMode: StudyMode = .all
+        @Published private(set) var frontType: FrontType = .meaning
         private(set) var eventPublisher = PassthroughSubject<Event, Never>()
 
         init(wordBook: WordBook) {
@@ -89,21 +90,19 @@ extension StudyView {
                     print("디버그: \(error)")
                 }
                 guard let words = words else { return }
-                self?.rawWords = words
+                self?.words = words
                 self?.filterWords()
             }
         }
         
         func shuffleWords() {
-            rawWords.shuffle()
+            words.shuffle()
             filterWords()
-            eventPublisher.send(StudyViewEvent.toFront(id: nil))
         }
         
         func toggleStudyMode() {
             studyMode = studyMode == .all ? .excludeSuccess : .all
             filterWords()
-            eventPublisher.send(StudyViewEvent.toFront(id: nil))
         }
         
         func handleEvent(_ event: Event) {
@@ -120,22 +119,24 @@ extension StudyView {
             WordService.updateStudyState(wordBookID: wordBookID, wordID: wordID, newState: state) { [weak self] error in
                 // FIXME: handle error
                 if let error = error { print(error); return }
-                guard let index = self?.rawWords.firstIndex(where: { $0.id == wordID }) else { return }
-                self?.rawWords[index].studyState = state
-                // 필터된 리스트에서는 아래 위치한 단어가 올라오기 때문에 다시 뒤집어 주어야 한다.
-                if self?.studyMode == .excludeSuccess {
-                    self?.eventPublisher.send(StudyViewEvent.toFront(id: wordID))
+                guard let self = self else { return }
+                guard let index = self.words.firstIndex(where: { $0.id == wordID }) else { return }
+                self.words[index].studyState = state
+                if self.studyMode == .excludeSuccess && state == .success {
+                    self.displays = self.displays.filter { $0.word.id != wordID }
                 }
-                self?.filterWords()
             }
         }
         
         private func filterWords() {
             switch studyMode {
             case .all:
-                words = rawWords
+                displays = words
+                            .map { WordDisplay(wordBook: wordBook, word: $0, frontType: frontType) }
             case .excludeSuccess:
-                words = rawWords.filter { $0.studyState != .success }
+                displays = words
+                            .filter { $0.studyState != .success }
+                            .map { WordDisplay(wordBook: wordBook, word: $0, frontType: frontType) }
             }
         }
     }

--- a/JWords/iOSView/Study/StudyView.swift
+++ b/JWords/iOSView/Study/StudyView.swift
@@ -60,6 +60,9 @@ struct StudyView: View {
                     Button(viewModel.studyMode.toggleButtonTitle) {
                         viewModel.toggleStudyMode()
                     }
+                    Button(viewModel.frontType.toggleButtonTitle) {
+                        viewModel.toggleFrontType()
+                    }
                 }
             }
         }
@@ -102,6 +105,11 @@ extension StudyView {
         
         func toggleStudyMode() {
             studyMode = studyMode == .all ? .excludeSuccess : .all
+            filterWords()
+        }
+        
+        func toggleFrontType() {
+            frontType = frontType == .meaning ? .kanji : .meaning
             filterWords()
         }
         

--- a/JWords/iOSView/Study/WordEditView.swift
+++ b/JWords/iOSView/Study/WordEditView.swift
@@ -16,8 +16,8 @@ struct WordEditView: View {
     
     var body: some View {
         VStack {
-            TextEditor(text: $viewModel.word.frontText)
-            TextEditor(text: $viewModel.word.backText)
+            TextEditor(text: $viewModel.word.meaningText)
+            TextEditor(text: $viewModel.word.ganaText)
             Button("수정") {
                 print("EditButton Pressed")
             }

--- a/JWords/iOSView/items/WordCell.swift
+++ b/JWords/iOSView/items/WordCell.swift
@@ -17,9 +17,9 @@ struct WordCell: View {
     
     private var hasImage: Bool {
         if isFront {
-            return viewModel.word.frontImageURL.isEmpty ? false : true
+            return viewModel.word.meaningImageURL.isEmpty ? false : true
         } else {
-            return viewModel.word.backImageURL.isEmpty ? false : true
+            return viewModel.word.ganaImageURL.isEmpty ? false : true
         }
     }
     
@@ -49,13 +49,13 @@ struct WordCell: View {
                     CellColor(state: $viewModel.word.studyState)
                     if isFront {
                         VStack {
-                            if !viewModel.word.frontText.isEmpty {
-                                Text(viewModel.word.frontText)
+                            if !viewModel.word.meaningText.isEmpty {
+                                Text(viewModel.word.meaningText)
                                     .minimumScaleFactor(0.5)
                                     .font(.system(size: 48))
                                     .lineLimit(3)
                             }
-                            if !viewModel.word.frontImageURL.isEmpty {
+                            if !viewModel.word.meaningImageURL.isEmpty {
                                 KFImage(viewModel.frontImageURL)
                                     .resizable()
                                     .scaledToFit()
@@ -63,13 +63,13 @@ struct WordCell: View {
                         }
                     } else {
                         VStack {
-                            if !viewModel.word.backText.isEmpty {
-                                Text(viewModel.word.backText)
+                            if !viewModel.word.ganaText.isEmpty {
+                                Text(viewModel.word.ganaText)
                                     .minimumScaleFactor(0.5)
                                     .font(.system(size: 48))
                                     .lineLimit(3)
                             }
-                            if !viewModel.word.backImageURL.isEmpty {
+                            if !viewModel.word.ganaImageURL.isEmpty {
                                 KFImage(viewModel.backImageURL)
                                     .resizable()
                                     .scaledToFit()
@@ -145,11 +145,11 @@ extension WordCell {
         }
         
         var frontImageURL: URL? {
-            URL(string: word.frontImageURL)
+            URL(string: word.meaningImageURL)
         }
         
         var backImageURL: URL? {
-            URL(string: word.backImageURL)
+            URL(string: word.ganaImageURL)
         }
         
         func updateStudyState(to state: StudyState) {
@@ -158,7 +158,7 @@ extension WordCell {
         
         func prefetchImage() {
             guard word.hasImage == true else { return }
-            let urls = [word.frontImageURL, word.backImageURL].compactMap { URL(string: $0) }
+            let urls = [word.meaningImageURL, word.ganaImageURL].compactMap { URL(string: $0) }
             let prefetcher = ImagePrefetcher(urls: urls) {
                 skippedResources, failedResources, completedResources in
                 print("prefetched image: \(completedResources)")


### PR DESCRIPTION
# 1. DB 수정
- Old document
![image](https://user-images.githubusercontent.com/70995840/183589033-2791d503-9a99-4b05-af84-91423dc8586f.png)
- New document
![image](https://user-images.githubusercontent.com/70995840/183589405-18d98bb5-7e11-46ee-be17-3fb8341162cd.png)
# 2. Word Model 수정
- Old Model
```swift
struct Word: Identifiable, Codable, Hashable{
    @DocumentID var id: String?
    var frontText: String = ""
    var frontImageURL: String = ""
    var backText: String = ""
    var backImageURL: String = ""
    var studyState: StudyState
    let timestamp: Timestamp
}
```
- New Model
```swift
struct Word: Identifiable, Codable, Hashable{
    @DocumentID var id: String?
    var meaningText: String = ""
    var meaningImageURL: String = ""
    var ganaText: String = ""
    var ganaImageURL: String = ""
    var kanjiText: String = ""
    var kanjiImageURL: String = ""
    var studyState: StudyState
    let timestamp: Timestamp
}
```
# 3. MacAddWordView 수정
- Old View
![image](https://user-images.githubusercontent.com/70995840/183590062-167079ba-56c8-48ff-a259-82cedc54c1db.png)
- New View
![image](https://user-images.githubusercontent.com/70995840/183590457-5ad9683a-469e-4418-aa41-9b72b76971a0.png)
# 4. 한자 및 가나 분리해서 출력
![한자가나 분리](https://user-images.githubusercontent.com/70995840/183590334-5ed85086-072c-4f96-94ca-33165befcfa2.gif)
# 5. 앞면 한자 모드 추가
![한자한글변환](https://user-images.githubusercontent.com/70995840/183590363-94164f88-286c-4f8d-a89e-9fb09fc8025a.gif)
