### PR TITLE
[Feature] Add WordBook in iOS

### DIFF
--- a/JWords/JWordsApp.swift
+++ b/JWords/JWordsApp.swift
@@ -23,7 +23,9 @@ struct JWordsApp: App {
     
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            NavigationView {
+                ContentView()
+            }
         }
     }
 }

--- a/JWords/iOSView/Home/HomeView.swift
+++ b/JWords/iOSView/Home/HomeView.swift
@@ -10,18 +10,52 @@ import SwiftUI
 struct HomeView: View {
     
     @ObservedObject private var viewModel = ViewModel()
+    @State private var showModal = false
     
     var body: some View {
-        NavigationView {
-            ScrollView {
-                VStack(spacing: 8) {
-                    ForEach(viewModel.wordBooks) { wordBook in
-                        HomeCell(wordBook: wordBook)
-                    }
+        ScrollView {
+            VStack(spacing: 8) {
+                ForEach(viewModel.wordBooks) { wordBook in
+                    HomeCell(wordBook: wordBook)
                 }
             }
         }
+        .navigationTitle("단어장 목록")
         .onAppear { viewModel.fetchWordBooks() }
+        .sheet(isPresented: $showModal) { WordBookAddModal(viewModel: viewModel) }
+        .toolbar {
+            ToolbarItem {
+                Button("+") { showModal = true }
+            }
+        }
+    }
+}
+
+// MARK: SubViews
+extension HomeView {
+    private struct WordBookAddModal: View {
+        @State var WordBookTitle: String = ""
+        @Environment(\.presentationMode) var mode
+        private let viewModel: ViewModel
+        
+        init(viewModel: ViewModel) {
+            self.viewModel = viewModel
+        }
+        
+        var body: some View {
+            VStack {
+                TextField("단어장 이름", text: $WordBookTitle)
+                HStack {
+                    Button("추가", action: { viewModel.AddWordBook(WordBookTitle); dismiss()  })
+                    Button("취소", role: .cancel, action: { dismiss() })
+                }
+            }
+            .padding()
+        }
+        
+        private func dismiss() {
+            mode.wrappedValue.dismiss()
+        }
     }
 }
 
@@ -37,6 +71,16 @@ extension HomeView {
                 if let wordBooks = wordBooks {
                     self?.wordBooks = wordBooks
                 }
+            }
+        }
+        
+        func AddWordBook(_ title: String) {
+            WordService.saveBook(title: title) { [weak self] error in
+                if let error = error {
+                    print(error)
+                    return
+                }
+                self?.fetchWordBooks()
             }
         }
     }


### PR DESCRIPTION
# 기능 소개
iOS 앱에서 새로운 단어장을 추가할 수 있도록 함
![새로운 단어장](https://user-images.githubusercontent.com/70995840/185778063-2329243c-0650-4da8-a4d9-bbe0d3807065.gif)
# 사용한 기술
sheet를 이용해 모달을 띄움
```swift
.sheet(isPresented: $showModal) { WordBookAddModal(viewModel: viewModel) }
```
```swift
// MARK: SubViews
extension HomeView {
    private struct WordBookAddModal: View {
        @State var WordBookTitle: String = ""
        @Environment(\.presentationMode) var mode
        private let viewModel: ViewModel
        
        init(viewModel: ViewModel) {
            self.viewModel = viewModel
        }
        
        var body: some View {
            VStack {
                TextField("단어장 이름", text: $WordBookTitle)
                HStack {
                    Button("추가", action: { viewModel.AddWordBook(WordBookTitle); dismiss()  })
                    Button("취소", role: .cancel, action: { dismiss() })
                }
            }
            .padding()
        }
        
        private func dismiss() {
            mode.wrappedValue.dismiss()
        }
    }
}
```
# 특이사항
원래는 Alert를 사용해서 구현하려고 했으나
[SwiftUI에서 TextField를 넣을 수 있는 Alert는 iOS16부터 적용된다고 함.](https://sarunw.com/posts/swiftui-alert-textfield/)
