### PR TITLE
[Feature] Fast input by trimming pasted text from dictionary

### DIFF
--- a/JWords/macView/MacAddWordView.swift
+++ b/JWords/macView/MacAddWordView.swift
@@ -64,6 +64,7 @@ extension MacAddWordView {
                 .onAppear { viewModel.getWordBooks() }
                 .onChange(of: viewModel.meaningText) { moveCursorToGanaWhenTap($0) }
                 .onChange(of: viewModel.ganaText) { moveCursorToKanjiWhenTap($0) }
+                .onChange(of: viewModel.ganaText) { viewModel.trimInput($0) }
             }
         }
         
@@ -282,6 +283,15 @@ extension MacAddWordView {
             case .kanji:
                 kanjiImage = image
             }
+        }
+        
+        func trimInput(_ input: String) {
+            guard input.contains("[") else { return }
+            var strings = input.split(separator: " ")
+            guard strings.count == 2 else { return }
+            strings[1] = strings[1].filter { !["[", "]"].contains($0) }
+            ganaText = String(strings[0])
+            kanjiText = String(strings[1])
         }
         
         func clearImageInput(_ inputType: InputType) {

--- a/JWords/macView/MacAddWordView.swift
+++ b/JWords/macView/MacAddWordView.swift
@@ -64,7 +64,7 @@ extension MacAddWordView {
                 .onAppear { viewModel.getWordBooks() }
                 .onChange(of: viewModel.meaningText) { moveCursorToGanaWhenTap($0) }
                 .onChange(of: viewModel.ganaText) { moveCursorToKanjiWhenTap($0) }
-                .onChange(of: viewModel.ganaText) { viewModel.trimInput($0) }
+                .onChange(of: viewModel.ganaText) { viewModel.trimPastedText($0) }
             }
         }
         
@@ -285,10 +285,12 @@ extension MacAddWordView {
             }
         }
         
-        func trimInput(_ input: String) {
+        // 네이버 사전에서 복사-붙여넣기할 때 "히라가나 [한자]" 형태로 된 텍스트 가나-한자로 구분
+        func trimPastedText(_ input: String) {
             guard input.contains("[") else { return }
             var strings = input.split(separator: " ")
-            guard strings.count == 2 else { return }
+            guard strings.count >= 2 else { return }
+            strings[0] = strings[0].filter { $0 != "-" } // 장음표시 제거
             strings[1] = strings[1].filter { !["[", "]"].contains($0) }
             ganaText = String(strings[0])
             kanjiText = String(strings[1])


### PR DESCRIPTION
# 네이버 사전에서 복사-붙여넣기 할 때 가나와 한자 분리해서 자동으로 입력해주는 기능
네이버 사전에서 단어를 복사 해올때 "히라가나 [한자]"의 형식으로 되어 있는데 이 텍스트를 자동으로 인식해서 가나와 한자를 분리해 줌
![가나한자구분](https://user-images.githubusercontent.com/70995840/186061618-b7fb70b8-2198-4d6f-a618-b8a664f84534.gif)
