### PR TITLE
[Feature] Close book

### DIFF
--- a/JWords.xcodeproj/project.pbxproj
+++ b/JWords.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		068D4CFC28B2189300F44F6E /* WordBookCloseViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 068D4CFB28B2189300F44F6E /* WordBookCloseViewModel.swift */; };
+		068D4CFC28B2189300F44F6E /* WordBookCloseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 068D4CFB28B2189300F44F6E /* WordBookCloseView.swift */; };
 		06A1F4E028670D97003440B0 /* Quick in Frameworks */ = {isa = PBXBuildFile; productRef = 06A1F4DF28670D97003440B0 /* Quick */; };
 		06A1F4E228670DA8003440B0 /* Quick in Frameworks */ = {isa = PBXBuildFile; productRef = 06A1F4E128670DA8003440B0 /* Quick */; };
 		06A1F4E428670DAE003440B0 /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = 06A1F4E328670DAE003440B0 /* Nimble */; };
@@ -88,7 +88,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		068D4CFB28B2189300F44F6E /* WordBookCloseViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordBookCloseViewModel.swift; sourceTree = "<group>"; };
+		068D4CFB28B2189300F44F6E /* WordBookCloseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordBookCloseView.swift; sourceTree = "<group>"; };
 		06A1F4D628670C99003440B0 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		06A564D5289E9C5100DBC2E0 /* WordEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordEditView.swift; sourceTree = "<group>"; };
 		06CEF2432866F1C800A620CC /* JWords.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JWords.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -302,7 +302,7 @@
 			children = (
 				5A67DC29286946F800AC156C /* StudyView.swift */,
 				06A564D5289E9C5100DBC2E0 /* WordEditView.swift */,
-				068D4CFB28B2189300F44F6E /* WordBookCloseViewModel.swift */,
+				068D4CFB28B2189300F44F6E /* WordBookCloseView.swift */,
 			);
 			path = Study;
 			sourceTree = "<group>";
@@ -544,7 +544,7 @@
 				5A67DC312869529700AC156C /* MacHomeView.swift in Sources */,
 				5AD8070B28A0EDE300ADB6F7 /* Events.swift in Sources */,
 				5ACE0A7628699BAD00A57660 /* WordBook.swift in Sources */,
-				068D4CFC28B2189300F44F6E /* WordBookCloseViewModel.swift in Sources */,
+				068D4CFC28B2189300F44F6E /* WordBookCloseView.swift in Sources */,
 				5A67DC27286944FF00AC156C /* Size.swift in Sources */,
 				5A1FADFB28A1FC87000ACBD2 /* DataResettingScript.swift in Sources */,
 				5ACE0A73286998F800A57660 /* Collections.swift in Sources */,

--- a/JWords.xcodeproj/project.pbxproj
+++ b/JWords.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		068D4CFC28B2189300F44F6E /* WordBookCloseViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 068D4CFB28B2189300F44F6E /* WordBookCloseViewModel.swift */; };
 		06A1F4E028670D97003440B0 /* Quick in Frameworks */ = {isa = PBXBuildFile; productRef = 06A1F4DF28670D97003440B0 /* Quick */; };
 		06A1F4E228670DA8003440B0 /* Quick in Frameworks */ = {isa = PBXBuildFile; productRef = 06A1F4E128670DA8003440B0 /* Quick */; };
 		06A1F4E428670DAE003440B0 /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = 06A1F4E328670DAE003440B0 /* Nimble */; };
@@ -87,6 +88,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		068D4CFB28B2189300F44F6E /* WordBookCloseViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordBookCloseViewModel.swift; sourceTree = "<group>"; };
 		06A1F4D628670C99003440B0 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		06A564D5289E9C5100DBC2E0 /* WordEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordEditView.swift; sourceTree = "<group>"; };
 		06CEF2432866F1C800A620CC /* JWords.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JWords.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -300,6 +302,7 @@
 			children = (
 				5A67DC29286946F800AC156C /* StudyView.swift */,
 				06A564D5289E9C5100DBC2E0 /* WordEditView.swift */,
+				068D4CFB28B2189300F44F6E /* WordBookCloseViewModel.swift */,
 			);
 			path = Study;
 			sourceTree = "<group>";
@@ -541,6 +544,7 @@
 				5A67DC312869529700AC156C /* MacHomeView.swift in Sources */,
 				5AD8070B28A0EDE300ADB6F7 /* Events.swift in Sources */,
 				5ACE0A7628699BAD00A57660 /* WordBook.swift in Sources */,
+				068D4CFC28B2189300F44F6E /* WordBookCloseViewModel.swift in Sources */,
 				5A67DC27286944FF00AC156C /* Size.swift in Sources */,
 				5A1FADFB28A1FC87000ACBD2 /* DataResettingScript.swift in Sources */,
 				5ACE0A73286998F800A57660 /* Collections.swift in Sources */,

--- a/JWords/DataService/WordService.swift
+++ b/JWords/DataService/WordService.swift
@@ -93,7 +93,7 @@ class WordService {
         }
     }
     
-    static func closeWordBook(of id: String, to to: String?, toMoveWords: [Word], completionHandler: FireStoreCompletion) {
+    static func closeWordBook(of id: String, to: String?, toMoveWords: [Word], completionHandler: FireStoreCompletion) {
         if let to = to {
             copyWords(toMoveWords, to: to) {
                 closeBook(id, completionHandler: completionHandler)

--- a/JWords/DataService/WordService.swift
+++ b/JWords/DataService/WordService.swift
@@ -92,4 +92,9 @@ class WordService {
             completionHandler(documents.count != 0 ? true : false, nil)
         }
     }
+    
+    static func closeWordBook(_ id: String, completionHandler: FireStoreCompletion) {
+        let field = ["_closed": true]
+        Constants.Collections.wordBooks.document(id).updateData(field, completion: completionHandler)
+    }
 }

--- a/JWords/DataService/WordService.swift
+++ b/JWords/DataService/WordService.swift
@@ -104,11 +104,13 @@ class WordService {
         
     }
     
+    // 단어장의 _closed field를 업데이트하는 함수
     static private func closeBook(_ id: String, completionHandler: FireStoreCompletion) {
         let field = ["_closed": true]
         Constants.Collections.wordBooks.document(id).updateData(field, completion: completionHandler)
     }
     
+    // 단어 여러개를 copy하는 기능 (dispatch group)
     static private func copyWords(_ words: [Word], to id: String, completionHandler: @escaping () -> Void) {
         let group = DispatchGroup()
         for word in words {
@@ -119,6 +121,7 @@ class WordService {
         }
     }
     
+    // 단어 1개 이동하는 기능
     static private func copyWord(_ word: Word, to id: String, group: DispatchGroup) {
         group.enter()
         let data: [String : Any] = ["timestamp": Timestamp(date: Date()),

--- a/JWords/Model/WordBook.swift
+++ b/JWords/Model/WordBook.swift
@@ -13,4 +13,10 @@ struct WordBook: Identifiable, Codable, Hashable {
     @DocumentID var id: String?
     var title: String
     let timestamp: Timestamp
+    private let _closed: Bool?
+    
+    var closed: Bool {
+        if let closed = _closed { return closed }
+        return false
+    }
 }

--- a/JWords/iOSView/Home/HomeCell.swift
+++ b/JWords/iOSView/Home/HomeCell.swift
@@ -21,9 +21,7 @@ struct HomeCell: View {
                 StudyView(wordBook: viewModel.wordBook)
             } label: {
                 HStack {
-                    VStack(alignment: .leading) {
-                        Text(viewModel.wordBook.title)
-                    }
+                    Text(viewModel.wordBook.title)
                     Spacer()
                 }
                 .padding(12)

--- a/JWords/iOSView/Home/HomeView.swift
+++ b/JWords/iOSView/Home/HomeView.swift
@@ -63,7 +63,7 @@ extension HomeView {
             WordService.getWordBooks { [weak self] wordBooks, error in
                 if let error = error { print("디버그: \(error.localizedDescription)"); return }
                 if let wordBooks = wordBooks {
-                    self?.wordBooks = wordBooks
+                    self?.wordBooks = wordBooks.filter { $0.closed == false }
                 }
             }
         }

--- a/JWords/iOSView/Home/HomeView.swift
+++ b/JWords/iOSView/Home/HomeView.swift
@@ -35,7 +35,7 @@ struct HomeView: View {
 extension HomeView {
     private struct WordBookAddModal: View {
         @State var WordBookTitle: String = ""
-        @Environment(\.presentationMode) var mode
+        @Environment(\.dismiss) var dismiss
         private let viewModel: ViewModel
         
         init(viewModel: ViewModel) {
@@ -52,20 +52,14 @@ extension HomeView {
             }
             .padding()
         }
-        
-        private func dismiss() {
-            mode.wrappedValue.dismiss()
-        }
     }
 }
 
 extension HomeView {
     final class ViewModel: ObservableObject {
         @Published private(set) var wordBooks: [WordBook] = []
-        private var isFetched: Bool = false
         
         func fetchWordBooks() {
-            if isFetched { return }
             WordService.getWordBooks { [weak self] wordBooks, error in
                 if let error = error { print("디버그: \(error.localizedDescription)"); return }
                 if let wordBooks = wordBooks {

--- a/JWords/iOSView/Study/StudyView.swift
+++ b/JWords/iOSView/Study/StudyView.swift
@@ -59,7 +59,7 @@ struct StudyView: View {
             viewModel.updateWords()
             resetDeviceWidth()
         }
-        .sheet(isPresented: $showCloseModal) { WordBookCloseView(wordBook: viewModel.wordBook) }
+        .sheet(isPresented: $showCloseModal) { WordBookCloseView(wordBook: viewModel.wordBook, toMoveWords: viewModel.toMoveWords) }
         #if os(iOS)
         // TODO: 화면 돌리면 알아서 다시 deviceWidth를 전달해서 cell 크기를 다시 계산한다.
         .onReceive(NotificationCenter.default.publisher(for: UIDevice.orientationDidChangeNotification)) { _ in
@@ -107,6 +107,10 @@ extension StudyView {
 
         init(wordBook: WordBook) {
             self.wordBook = wordBook
+        }
+        
+        var toMoveWords: [Word] {
+            rawWords.filter { $0.studyState != .success }
         }
         
         func updateWords() {

--- a/JWords/iOSView/Study/StudyView.swift
+++ b/JWords/iOSView/Study/StudyView.swift
@@ -40,7 +40,7 @@ struct StudyView: View {
     @State private var deviceWidth: CGFloat = Constants.Size.deviceWidth
     @State private var showEditModal: Bool = false
     @State private var showCloseModal: Bool = false
-    @State private var didClosed: Bool = false
+    @State private var showDismiss: Bool = false
     
     init(wordBook: WordBook) {
         self.viewModel = ViewModel(wordBook: wordBook)
@@ -61,9 +61,9 @@ struct StudyView: View {
             resetDeviceWidth()
         }
         .sheet(isPresented: $showCloseModal, onDismiss: {
-            if didClosed { dismiss() }
+            if showDismiss { dismiss() }
         }) {
-            WordBookCloseView(wordBook: viewModel.wordBook, toMoveWords: viewModel.toMoveWords, didClosed: $didClosed)
+            WordBookCloseView(wordBook: viewModel.wordBook, toMoveWords: viewModel.toMoveWords, didClosed: $showDismiss)
         }
         #if os(iOS)
         // TODO: 화면 돌리면 알아서 다시 deviceWidth를 전달해서 cell 크기를 다시 계산한다.

--- a/JWords/iOSView/Study/StudyView.swift
+++ b/JWords/iOSView/Study/StudyView.swift
@@ -80,6 +80,11 @@ struct StudyView: View {
                 }
             }
         }
+        .toolbar() {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button("닫기") {  }
+            }
+        }
         #endif
     }
     

--- a/JWords/iOSView/Study/StudyView.swift
+++ b/JWords/iOSView/Study/StudyView.swift
@@ -40,6 +40,7 @@ struct StudyView: View {
     @State private var deviceWidth: CGFloat = Constants.Size.deviceWidth
     @State private var showEditModal: Bool = false
     @State private var showCloseModal: Bool = false
+    @State private var didClosed: Bool = false
     
     init(wordBook: WordBook) {
         self.viewModel = ViewModel(wordBook: wordBook)
@@ -59,7 +60,11 @@ struct StudyView: View {
             viewModel.updateWords()
             resetDeviceWidth()
         }
-        .sheet(isPresented: $showCloseModal) { WordBookCloseView(wordBook: viewModel.wordBook, toMoveWords: viewModel.toMoveWords) }
+        .sheet(isPresented: $showCloseModal, onDismiss: {
+            if didClosed { dismiss() }
+        }) {
+            WordBookCloseView(wordBook: viewModel.wordBook, toMoveWords: viewModel.toMoveWords, didClosed: $didClosed)
+        }
         #if os(iOS)
         // TODO: 화면 돌리면 알아서 다시 deviceWidth를 전달해서 cell 크기를 다시 계산한다.
         .onReceive(NotificationCenter.default.publisher(for: UIDevice.orientationDidChangeNotification)) { _ in

--- a/JWords/iOSView/Study/StudyView.swift
+++ b/JWords/iOSView/Study/StudyView.swift
@@ -165,14 +165,6 @@ extension StudyView {
             }
         }
         
-        func closeWordBook(completionHandler: @escaping () -> Void) {
-            guard let id = wordBook.id else { return }
-            WordService.closeWordBook(id) { error in
-                if let error = error { print(error); return }
-                completionHandler()
-            }
-        }
-        
         private func filterWords() {
             switch studyMode {
             case .all:

--- a/JWords/iOSView/Study/WordBookCloseView.swift
+++ b/JWords/iOSView/Study/WordBookCloseView.swift
@@ -13,52 +13,50 @@ struct WordBookCloseView: View {
     
     init(wordBook: WordBook) {
         self.viewModel = ViewModel(toClose: wordBook)
-//        viewModel.getWordBooks()
+        // FIXME: 이 API 호출은 3번 실행됨. (Modal이 3번 init되기 때문)
+        viewModel.getWordBooks()
     }
     
     var body: some View {
         VStack {
             Text("틀린 단어들을 이동할 단어장을 골라주세요.")
             Picker("이동할 단어장 고르기", selection: $viewModel.selectedID) {
-                if viewModel.wordBooks.isEmpty {
-                    Text("로딩중")
-                        .tag(nil as String?)
-                }
-                ForEach(viewModel.wordBooks, id: \.id) { wordbook in
-                    Text(wordbook.title)
-                        .tag(wordbook.id as String?)
+                Text(viewModel.wordBooks.isEmpty ? "로딩중" : "이동 안함")
+                    .tag(nil as String?)
+                ForEach(viewModel.wordBooks) {
+                    Text($0.title)
+                        .tag($0.id as String?)
                 }
             }
             .pickerStyle(.wheel)
         }
-        .onAppear { viewModel.getWordBooks() }
     }
+    
 }
 
 extension WordBookCloseView {
     final class ViewModel: ObservableObject {
         private let toClose: WordBook
         @Published var wordBooks = [WordBook]()
-        @Published var selectedID: String?
+        var selectedID: String?
         
         init(toClose: WordBook) {
             self.toClose = toClose
         }
         
         func getWordBooks() {
-            WordService.getWordBooks { wordBooks, error in
+            WordService.getWordBooks { [weak self] books, error in
                 if let error = error {
                     print(error)
                     return
                 }
                 
-                guard let wordBooks = wordBooks else {
-                    print("Debug: No wordBook Found")
+                guard let books = books else {
+                    print("Debug: No wordbook Found")
                     return
                 }
-
-                self.wordBooks = wordBooks
-                print("디버그: \(self.wordBooks)")
+                
+                self?.wordBooks = books
             }
         }
     }

--- a/JWords/iOSView/Study/WordBookCloseView.swift
+++ b/JWords/iOSView/Study/WordBookCloseView.swift
@@ -11,9 +11,11 @@ struct WordBookCloseView: View {
     @ObservedObject private var viewModel: ViewModel
     @Environment(\.dismiss) private var dismiss
     @State private var showProgressView = false
+    @Binding private var didClosed: Bool
     
-    init(wordBook: WordBook, toMoveWords: [Word]) {
+    init(wordBook: WordBook, toMoveWords: [Word], didClosed: Binding<Bool>) {
         self.viewModel = ViewModel(toClose: wordBook, toMoveWords: toMoveWords)
+        self._didClosed = didClosed
         // FIXME: 이 API 호출은 3번 실행됨. (Modal이 3번 init되기 때문)
         viewModel.getWordBooks()
     }
@@ -36,11 +38,15 @@ struct WordBookCloseView: View {
                 .pickerStyle(.wheel)
                 HStack {
                     Button("취소") {
+                        didClosed = false
                         dismiss()
                     }
                     Button(viewModel.selectedID != nil ? "이동" : "닫기") {
                         showProgressView = true
-                        viewModel.closeBook { dismiss() }
+                        viewModel.closeBook {
+                            didClosed = true
+                            dismiss()
+                        }
                     }
                 }
             }

--- a/JWords/iOSView/Study/WordBookCloseView.swift
+++ b/JWords/iOSView/Study/WordBookCloseView.swift
@@ -29,6 +29,14 @@ struct WordBookCloseView: View {
                 }
             }
             .pickerStyle(.wheel)
+            HStack {
+                Button("취소") {
+                    dismiss()
+                }
+                Button("이동") {
+                    
+                }
+            }
         }
     }
     

--- a/JWords/iOSView/Study/WordBookCloseView.swift
+++ b/JWords/iOSView/Study/WordBookCloseView.swift
@@ -11,15 +11,15 @@ struct WordBookCloseView: View {
     @ObservedObject private var viewModel: ViewModel
     @Environment(\.dismiss) private var dismiss
     
-    init(wordBook: WordBook) {
-        self.viewModel = ViewModel(toClose: wordBook)
+    init(wordBook: WordBook, toMoveWords: [Word]) {
+        self.viewModel = ViewModel(toClose: wordBook, toMoveWords: toMoveWords)
         // FIXME: 이 API 호출은 3번 실행됨. (Modal이 3번 init되기 때문)
         viewModel.getWordBooks()
     }
     
     var body: some View {
         VStack {
-            Text("틀린 단어들을 이동할 단어장을 골라주세요.")
+            Text("\(viewModel.toMoveWords.count)개의 틀린 단어들을 이동할 단어장을 골라주세요.")
             Picker("이동할 단어장 고르기", selection: $viewModel.selectedID) {
                 Text(viewModel.wordBooks.isEmpty ? "로딩중" : "이동 안함")
                     .tag(nil as String?)
@@ -45,11 +45,14 @@ struct WordBookCloseView: View {
 extension WordBookCloseView {
     final class ViewModel: ObservableObject {
         private let toClose: WordBook
+        let toMoveWords: [Word]
+        
         @Published var wordBooks = [WordBook]()
         var selectedID: String?
         
-        init(toClose: WordBook) {
+        init(toClose: WordBook, toMoveWords: [Word]) {
             self.toClose = toClose
+            self.toMoveWords = toMoveWords
         }
         
         func getWordBooks() {

--- a/JWords/iOSView/Study/WordBookCloseViewModel.swift
+++ b/JWords/iOSView/Study/WordBookCloseViewModel.swift
@@ -1,0 +1,65 @@
+//
+//  WordBookCloseView.swift
+//  JWords
+//
+//  Created by JW Moon on 2022/08/21.
+//
+
+import SwiftUI
+
+struct WordBookCloseView: View {
+    @ObservedObject private var viewModel: ViewModel
+    @Environment(\.dismiss) private var dismiss
+    
+    init(wordBook: WordBook) {
+        self.viewModel = ViewModel(toClose: wordBook)
+//        viewModel.getWordBooks()
+    }
+    
+    var body: some View {
+        VStack {
+            Text("틀린 단어들을 이동할 단어장을 골라주세요.")
+            Picker("이동할 단어장 고르기", selection: $viewModel.selectedID) {
+                if viewModel.wordBooks.isEmpty {
+                    Text("로딩중")
+                        .tag(nil as String?)
+                }
+                ForEach(viewModel.wordBooks, id: \.id) { wordbook in
+                    Text(wordbook.title)
+                        .tag(wordbook.id as String?)
+                }
+            }
+            .pickerStyle(.wheel)
+        }
+        .onAppear { viewModel.getWordBooks() }
+    }
+}
+
+extension WordBookCloseView {
+    final class ViewModel: ObservableObject {
+        private let toClose: WordBook
+        @Published var wordBooks = [WordBook]()
+        @Published var selectedID: String?
+        
+        init(toClose: WordBook) {
+            self.toClose = toClose
+        }
+        
+        func getWordBooks() {
+            WordService.getWordBooks { wordBooks, error in
+                if let error = error {
+                    print(error)
+                    return
+                }
+                
+                guard let wordBooks = wordBooks else {
+                    print("Debug: No wordBook Found")
+                    return
+                }
+
+                self.wordBooks = wordBooks
+                print("디버그: \(self.wordBooks)")
+            }
+        }
+    }
+}


### PR DESCRIPTION
# 단어장 닫기
## 기능 소개
다 외운 단어장을 닫을 수 있다. 닫는 단어장에서 아직 못 외운 단어들은 다른 단어장으로 옮길 수 있다.
## 기술 포인트
### Modal & Picker
Modal과 Picker를 활용해서 이동할 단어장을 고를 수 있도록 함
![modal picker](https://user-images.githubusercontent.com/70995840/186091183-b6b516c6-d74a-43b6-bceb-0e83cf95ad53.gif)
### Picker에서 nil을 선택할 수 있게 함.
```swift
Picker("이동할 단어장 고르기", selection: $viewModel.selectedID) {
    Text(viewModel.wordBooks.isEmpty ? "로딩중" : "이동 안함")
        .tag(nil as String?)
    ForEach(viewModel.wordBooks) {
        Text($0.title)
            .tag($0.id as String?)
    }
}
```
### 단어장이 닫히면 StudyView가 dismiss 되도록 하고 취소하면 dismiss 되지 않도록 함
```swift
// StudyView에 State 변수를 선언하고
@State private var didClosed: Bool = false

// 하위 View에 Binding으로 참조를 전달
// 하위 View에서 닫히면 true, 안닫히면 false를 할당해서 sheet가 dismiss될 때 StudyView를 dismiss할지 결정
.sheet(isPresented: $showCloseModal, onDismiss: {
    if didClosed { dismiss() }
}) {
    WordBookCloseView(wordBook: viewModel.wordBook, toMoveWords: viewModel.toMoveWords, didClosed: $didClosed)
}
```
단어장 닫음
![dismiss](https://user-images.githubusercontent.com/70995840/186091751-bd30a75e-21e1-40d4-9343-de7e90d8ab72.gif)
단어장 닫기 취소
![cancelled](https://user-images.githubusercontent.com/70995840/186091895-b309be4d-18e4-4fdb-b7d5-5078f3761c70.gif)
### Dispatch Group을 활용해서 단어들이 다 복사되고 난 뒤에 단어장이 닫히도록 함
```swift
static func closeWordBook(of id: String, to: String?, toMoveWords: [Word], completionHandler: FireStoreCompletion) {
    if let to = to {
        copyWords(toMoveWords, to: to) {
            closeBook(id, completionHandler: completionHandler)
        }
    } else {
        closeBook(id, completionHandler: completionHandler)
    }
    
}

// 단어장의 _closed field를 업데이트하는 함수
static private func closeBook(_ id: String, completionHandler: FireStoreCompletion) {
    let field = ["_closed": true]
    Constants.Collections.wordBooks.document(id).updateData(field, completion: completionHandler)
}

// 단어 여러개를 copy하는 기능 (dispatch group)
static private func copyWords(_ words: [Word], to id: String, completionHandler: @escaping () -> Void) {
    let group = DispatchGroup()
    for word in words {
        copyWord(word, to: id, group: group)
    }
    group.notify(queue: .global()) {
        completionHandler()
    }
}

// 단어 1개 이동하는 기능
static private func copyWord(_ word: Word, to id: String, group: DispatchGroup) {
    group.enter()
    let data: [String : Any] = ["timestamp": Timestamp(date: Date()),
                                "meaningText": word.meaningText,
                                "meaningImageURL": word.meaningImageURL,
                                "ganaText": word.ganaText,
                                "ganaImageURL": word.ganaImageURL,
                                "kanjiText": word.kanjiText,
                                "kanjiImageURL": word.kanjiImageURL,
                                "studyState": StudyState.undefined.rawValue]
    Constants.Collections.word(id).addDocument(data: data) { error in
        //TODO: handle error
        if let error = error { print(error) }
        group.leave()
    }
}
```
