### PR TITLE
[Feature] Search samples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 xcuserdata/
+GoogleService-Info.plist

--- a/JWords.xcodeproj/project.pbxproj
+++ b/JWords.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		06CEF2922866F86700A620CC /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 06CEF2912866F86700A620CC /* FirebaseStorage */; };
 		5A1FADFB28A1FC87000ACBD2 /* DataResettingScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1FADFA28A1FC87000ACBD2 /* DataResettingScript.swift */; };
 		5A5328C3286C126C0080D500 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 5A5328C2286C126C0080D500 /* Kingfisher */; };
+		5A5740A828BDA8900080A2E2 /* WordExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A5740A728BDA8900080A2E2 /* WordExamples.swift */; };
 		5A5FF62F286A8F69000150A7 /* ImageUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A5FF62E286A8F68000150A7 /* ImageUploader.swift */; };
 		5A5FF632286AD79E000150A7 /* ImageCompressor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A5FF631286AD79E000150A7 /* ImageCompressor.swift */; };
 		5A67DC1C2869426600AC156C /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 5A67DC1B2869426500AC156C /* GoogleService-Info.plist */; };
@@ -106,6 +107,7 @@
 		06CEF2772866F32700A620CC /* JWordsAcceptanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWordsAcceptanceTests.swift; sourceTree = "<group>"; };
 		06CEF27E2866F38500A620CC /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		5A1FADFA28A1FC87000ACBD2 /* DataResettingScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataResettingScript.swift; sourceTree = "<group>"; };
+		5A5740A728BDA8900080A2E2 /* WordExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordExamples.swift; sourceTree = "<group>"; };
 		5A5FF62E286A8F68000150A7 /* ImageUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUploader.swift; sourceTree = "<group>"; };
 		5A5FF631286AD79E000150A7 /* ImageCompressor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCompressor.swift; sourceTree = "<group>"; };
 		5A67DC1B2869426500AC156C /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
@@ -341,6 +343,7 @@
 				5ACE0A7528699BAD00A57660 /* WordBook.swift */,
 				5ACE0A7728699BB400A57660 /* Word.swift */,
 				5AD8070A28A0EDE300ADB6F7 /* Events.swift */,
+				5A5740A728BDA8900080A2E2 /* WordExamples.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -546,6 +549,7 @@
 				5ACE0A7628699BAD00A57660 /* WordBook.swift in Sources */,
 				068D4CFC28B2189300F44F6E /* WordBookCloseView.swift in Sources */,
 				5A67DC27286944FF00AC156C /* Size.swift in Sources */,
+				5A5740A828BDA8900080A2E2 /* WordExamples.swift in Sources */,
 				5A1FADFB28A1FC87000ACBD2 /* DataResettingScript.swift in Sources */,
 				5ACE0A73286998F800A57660 /* Collections.swift in Sources */,
 				5A67DC2D2869470C00AC156C /* WordCell.swift in Sources */,

--- a/JWords/Constants/Collections.swift
+++ b/JWords/Constants/Collections.swift
@@ -22,5 +22,10 @@ extension Constants {
             .document(bookID)
             .collection("words")
         }
+        static let examples =
+            Firestore.firestore()
+            .collection("develop")
+            .document("data")
+            .collection("examples")
     }
 }

--- a/JWords/DataService/DataResettingScript.swift
+++ b/JWords/DataService/DataResettingScript.swift
@@ -34,29 +34,67 @@ class DataResettingScript {
 //        }
 //    }
     
-    // 각 단어장에서 추출한 단어들을 wordExamples로 만들어서 옮기는 과정
-    static func moveWordsToWordExamples() {
-        WordService.getWordBooks { books, error in
-            if let error = error {
-                print(error)
-                return
-            }
-            
-        }
-    }
+//    // 각 단어장에서 추출한 단어들을 wordExamples로 만들어서 옮기는 과정
+//    static func moveWordsToWordExamples() {
+//        // 단어장 전부 가져오기
+//        WordService.getWordBooks { books, error in
+//            if let error = error {
+//                print(error)
+//                return
+//            }
+//            guard let books = books else {
+//                print("books is nil")
+//                return
+//            }
+//            // 모든 단어장 순환해서
+//            for book in books {
+//                // 단어장에 있는 단어 전부 fetch 해오기
+//                WordService.getWords(wordBookID: book.id!) { words, error in
+//                    if let error = error {
+//                        print(error)
+//                        return
+//                    }
+//                    guard let words = words else {
+//                        print("words is nil in wordbooks \(book.id!)")
+//                        return
+//                    }
+//                    // 모든 단어 wordExample로 만들어서 저장
+//                    for word in words {
+//                        saveWordExample(word)
+//                    }
+//                }
+//            }
+//            
+//        }
+//    }
+//    
+//    // 이미 있는 단어를 examples에 저장하는 함수
+//    static func saveWordExample(_ word: Word) {
+//        let data: [String : Any] = ["timestamp": Timestamp(date: Date()),
+//                                    "meaningText": word.meaningText,
+//                                    "meaningImageURL": word.meaningImageURL,
+//                                    "ganaText": word.ganaText,
+//                                    "ganaImageURL": word.ganaImageURL,
+//                                    "kanjiText": word.kanjiText,
+//                                    "kanjiImageURL": word.kanjiImageURL,
+//                                    "used": 0]
+//        Constants.Collections.examples.addDocument(data: data)
+//    }
     
-    // 새로운 단어장을 모두 가져온다
-    private static func getNewWordBooks(wordBook: WordBook, completion: @escaping ([WordBook]) -> Void) {
-        Firestore.firestore()
-            .collection("develop")
-            .document("data")
-            .collection("wordBooks")
-            .getDocuments { snapshot, _ in
-                guard let documents = snapshot?.documents else { return }
-                let wordBooks = documents.compactMap({ try? $0.data(as: WordBook.self) })
-                completion(wordBooks)
-            }
-    }
+    // 각 단어장에서 단어들 모두 가져와서 WordExampleInput으로 바꾸는 함수
+    
+//    // 새로운 단어장을 모두 가져온다
+//    private static func getNewWordBooks(wordBook: WordBook, completion: @escaping ([WordBook]) -> Void) {
+//        Firestore.firestore()
+//            .collection("develop")
+//            .document("data")
+//            .collection("wordBooks")
+//            .getDocuments { snapshot, _ in
+//                guard let documents = snapshot?.documents else { return }
+//                let wordBooks = documents.compactMap({ try? $0.data(as: WordBook.self) })
+//                completion(wordBooks)
+//            }
+//    }
     
 //    // 기존 단어장의 단어장을 가져와서 새로운 단어장에 쓴다.
 //    private static func resetWordData(oldID: String, newID: String) {

--- a/JWords/DataService/DataResettingScript.swift
+++ b/JWords/DataService/DataResettingScript.swift
@@ -5,10 +5,10 @@
 //  Created by Jong Won Moon on 2022/08/09.
 //
 
-//import Firebase
-//
-//class DataResettingScript {
-//    // 전체 데이터를 새로 작성하는 함수
+import Firebase
+
+class DataResettingScript {
+//    // 전체 데이터를 새로 작성하는 함수 (단어장 그대로 옮기기)
 //    static func resetBookData() {
 //        // 기존의 단어장의 데이터를 동일하게 새로운 단어장을 만든다.
 //        WordService.getWordBooks { wordBooks, _ in
@@ -33,20 +33,31 @@
 //            }
 //        }
 //    }
-//    
-//    // 새로운 단어장을 모두 가져온다
-//    private static func getNewWordBooks(wordBook: WordBook, completion: @escaping ([WordBook]) -> Void) {
-//        Firestore.firestore()
-//            .collection("develop")
-//            .document("data")
-//            .collection("wordBooks")
-//            .getDocuments { snapshot, _ in
-//                guard let documents = snapshot?.documents else { return }
-//                let wordBooks = documents.compactMap({ try? $0.data(as: WordBook.self) })
-//                completion(wordBooks)
-//            }
-//    }
-//    
+    
+    // 각 단어장에서 추출한 단어들을 wordExamples로 만들어서 옮기는 과정
+    static func moveWordsToWordExamples() {
+        WordService.getWordBooks { books, error in
+            if let error = error {
+                print(error)
+                return
+            }
+            
+        }
+    }
+    
+    // 새로운 단어장을 모두 가져온다
+    private static func getNewWordBooks(wordBook: WordBook, completion: @escaping ([WordBook]) -> Void) {
+        Firestore.firestore()
+            .collection("develop")
+            .document("data")
+            .collection("wordBooks")
+            .getDocuments { snapshot, _ in
+                guard let documents = snapshot?.documents else { return }
+                let wordBooks = documents.compactMap({ try? $0.data(as: WordBook.self) })
+                completion(wordBooks)
+            }
+    }
+    
 //    // 기존 단어장의 단어장을 가져와서 새로운 단어장에 쓴다.
 //    private static func resetWordData(oldID: String, newID: String) {
 //        WordService.getWords(wordBookID: oldID) { words, _ in
@@ -70,4 +81,5 @@
 //            }
 //        }
 //    }
-//}
+    
+}

--- a/JWords/DataService/DataResettingScript.swift
+++ b/JWords/DataService/DataResettingScript.swift
@@ -5,9 +5,9 @@
 //  Created by Jong Won Moon on 2022/08/09.
 //
 
-import Firebase
-
-class DataResettingScript {
+//import Firebase
+//
+//class DataResettingScript {
 //    // 전체 데이터를 새로 작성하는 함수 (단어장 그대로 옮기기)
 //    static func resetBookData() {
 //        // 기존의 단어장의 데이터를 동일하게 새로운 단어장을 만든다.
@@ -64,10 +64,10 @@ class DataResettingScript {
 //                    }
 //                }
 //            }
-//            
+//
 //        }
 //    }
-//    
+//
 //    // 이미 있는 단어를 examples에 저장하는 함수
 //    static func saveWordExample(_ word: Word) {
 //        let data: [String : Any] = ["timestamp": Timestamp(date: Date()),
@@ -120,4 +120,4 @@ class DataResettingScript {
 //        }
 //    }
     
-}
+//}

--- a/JWords/DataService/WordService.swift
+++ b/JWords/DataService/WordService.swift
@@ -133,6 +133,15 @@ class WordService {
             }
     }
     
+    // Examples 사용되서 used에 + 1하는 함수
+    static func updateUsed(of example: WordExample) {
+        guard let id = example.id else {
+            print("No id of example in updateUsed")
+            return
+        }
+        Constants.Collections.examples.document(id).updateData(["used" : example.used + 1])
+    }
+    
     // 단어장의 _closed field를 업데이트하는 함수
     static private func closeBook(_ id: String, completionHandler: FireStoreCompletion) {
         let field = ["_closed": true]

--- a/JWords/DataService/WordService.swift
+++ b/JWords/DataService/WordService.swift
@@ -104,6 +104,23 @@ class WordService {
         
     }
     
+    // Examples를 검색하는 함수
+    static func fetchExamples(_ query: String, completionHandler: @escaping ([WordExample]?, Error?) -> Void) {
+        Constants.Collections.examples
+            .whereField("meaningText", isGreaterThanOrEqualTo: query)
+            .whereField("meaningText", isLessThan: query + "힣")
+            .getDocuments { snapshot, error in
+                if let error = error {
+                    completionHandler(nil, error)
+                }
+                guard let documents = snapshot?.documents else { return }
+                let examples = documents
+                        .compactMap { try? $0.data(as: WordExample.self) }
+                        .sorted(by: { $0.used > $1.used })
+                completionHandler(examples, nil)
+            }
+    }
+    
     // 단어장의 _closed field를 업데이트하는 함수
     static private func closeBook(_ id: String, completionHandler: FireStoreCompletion) {
         let field = ["_closed": true]

--- a/JWords/DataService/WordService.swift
+++ b/JWords/DataService/WordService.swift
@@ -76,6 +76,18 @@ class WordService {
         }
     }
     
+    static func saveExample(wordInput: WordInput) {
+        let data: [String : Any] = ["timestamp": Timestamp(date: Date()),
+                                    "meaningText": wordInput.meaningText,
+                                    "meaningImageURL": "",
+                                    "ganaText": wordInput.ganaText,
+                                    "ganaImageURL": "",
+                                    "kanjiText": wordInput.kanjiText,
+                                    "kanjiImageURL": "",
+                                    "used": 0]
+        Constants.Collections.examples.addDocument(data: data)
+    }
+    
     static func updateStudyState(wordBookID: String, wordID: String, newState: StudyState,  completionHandler: @escaping (Error?) -> Void) {
         Constants.Collections.word(wordBookID).document(wordID).updateData(["studyState" : newState.rawValue]) { error in
             completionHandler(error)

--- a/JWords/Model/Word.swift
+++ b/JWords/Model/Word.swift
@@ -47,4 +47,8 @@ struct WordInput {
     let kanjiImage: InputImageType?
     let studyState: StudyState = .undefined
     let timestamp: Timestamp = Timestamp(date: Date())
+    
+    var hasImage: Bool {
+        self.meaningImage != nil || self.ganaImage != nil || self.kanjiImage != nil
+    }
 }

--- a/JWords/Model/WordExamples.swift
+++ b/JWords/Model/WordExamples.swift
@@ -1,0 +1,42 @@
+//
+//  WordExamples.swift
+//  JWords
+//
+//  Created by Jong Won Moon on 2022/08/30.
+//
+
+
+import FirebaseFirestoreSwift
+import Firebase
+
+struct WordExample: Identifiable, Codable, Hashable {
+    @DocumentID var id: String?
+    var meaningText: String = ""
+    var meaningImageURL: String = ""
+    var ganaText: String = ""
+    var ganaImageURL: String = ""
+    var kanjiText: String = ""
+    var kanjiImageURL: String = ""
+    let timestamp: Timestamp
+    let used: Int
+}
+
+struct WordExampleInput {
+    let meaningText: String
+    let meaningImageURL: String
+    let ganaText: String
+    let ganaImageURL: String
+    let kanjiText: String
+    let kanjiImageURL: String
+    let timestamp: Timestamp = Timestamp(date: Date())
+    let used: Int = 0
+    
+    init(from word: Word) {
+        self.meaningText = word.meaningText
+        self.meaningImageURL = word.meaningImageURL
+        self.ganaText = word.ganaText
+        self.ganaImageURL = word.ganaImageURL
+        self.kanjiText = word.kanjiText
+        self.kanjiImageURL = word.kanjiImageURL
+    }
+}

--- a/JWords/Model/WordExamples.swift
+++ b/JWords/Model/WordExamples.swift
@@ -20,23 +20,3 @@ struct WordExample: Identifiable, Codable, Hashable {
     let timestamp: Timestamp
     let used: Int
 }
-
-struct WordExampleInput {
-    let meaningText: String
-    let meaningImageURL: String
-    let ganaText: String
-    let ganaImageURL: String
-    let kanjiText: String
-    let kanjiImageURL: String
-    let timestamp: Timestamp = Timestamp(date: Date())
-    let used: Int = 0
-    
-    init(from word: Word) {
-        self.meaningText = word.meaningText
-        self.meaningImageURL = word.meaningImageURL
-        self.ganaText = word.ganaText
-        self.ganaImageURL = word.ganaImageURL
-        self.kanjiText = word.kanjiText
-        self.kanjiImageURL = word.kanjiImageURL
-    }
-}

--- a/JWords/Model/WordExamples.swift
+++ b/JWords/Model/WordExamples.swift
@@ -19,4 +19,8 @@ struct WordExample: Identifiable, Codable, Hashable {
     var kanjiImageURL: String = ""
     let timestamp: Timestamp
     let used: Int
+    
+    var hasImage: Bool {
+        !self.meaningImageURL.isEmpty || !self.ganaImageURL.isEmpty || !self.kanjiImageURL.isEmpty
+    }
 }


### PR DESCRIPTION
# 샘플 단어 검색
## 기능 소개
예전에 공부 했던 단어를 다시 저장하고 싶을 때 다시 적을 필요없이 기존의 데이터를 가져다가 다시 저장할 수 있는 기능
![샘플단어](https://user-images.githubusercontent.com/70995840/187368484-c4d9a702-c5e1-46a6-9c75-7fefeadd2f2d.gif)
## 기술 포인트
### Firestore에서 문자열이 포함된 결과 검색하는 법
query 보다 크고 뒤에 "힣" (한글의 마지막 글자)을 붙인 글자보다 작은 글자들을 찾아오면 됨 (문자열의 비교는 아스키 코드 기준)
```swift
Constants.Collections.examples
    .whereField("meaningText", isGreaterThanOrEqualTo: query)
    .whereField("meaningText", isLessThan: query + "힣")
```