### PR TITLE
[Fix] prevent future wordBooks added to today list

### DIFF
--- a/JWords/Model/WordBook.swift
+++ b/JWords/Model/WordBook.swift
@@ -40,7 +40,7 @@ struct WordBookImpl: WordBook {
         let dayFromToday = self.dayFromToday
         let reviewInterval = [3, 7, 14, 28]
         
-        if dayFromToday < 3 {
+        if dayFromToday >= 0 && dayFromToday < 3 {
             return .study
         } else if reviewInterval.contains(dayFromToday) {
             return .review


### PR DESCRIPTION
# 미래의 단어장이 오늘의 단어장 목록에 추가되는 것을 방지함
## before
![미래 추가 방지](https://user-images.githubusercontent.com/70995840/195010934-14bf0d05-3d58-4af7-88f8-3e58ca2397ef.gif)
## after
![미래추가 방지 after](https://user-images.githubusercontent.com/70995840/195010946-eb4fcb9e-0e25-44d6-ade5-2c68e675e9a9.gif)