### PR TITLE
[Feature] Move words to other wordbook

### DIFF
--- a/JWords.xcodeproj/project.pbxproj
+++ b/JWords.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		068D4CFC28B2189300F44F6E /* WordBookCloseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 068D4CFB28B2189300F44F6E /* WordBookCloseView.swift */; };
+		068D4CFC28B2189300F44F6E /* WordMoveView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 068D4CFB28B2189300F44F6E /* WordMoveView.swift */; };
 		0697715328CCA71700569280 /* WordInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0697715228CCA71700569280 /* WordInput.swift */; };
 		0697715528CCCF1300569280 /* MacAddBookViewModelTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0697715428CCCF1200569280 /* MacAddBookViewModelTest.swift */; };
 		0697715B28CCD05100569280 /* MockWordBookService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0697715A28CCD05000569280 /* MockWordBookService.swift */; };
@@ -111,7 +111,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		068D4CFB28B2189300F44F6E /* WordBookCloseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordBookCloseView.swift; sourceTree = "<group>"; };
+		068D4CFB28B2189300F44F6E /* WordMoveView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordMoveView.swift; sourceTree = "<group>"; };
 		0697715228CCA71700569280 /* WordInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordInput.swift; sourceTree = "<group>"; };
 		0697715428CCCF1200569280 /* MacAddBookViewModelTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacAddBookViewModelTest.swift; sourceTree = "<group>"; };
 		0697715A28CCD05000569280 /* MockWordBookService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWordBookService.swift; sourceTree = "<group>"; };
@@ -415,7 +415,7 @@
 			children = (
 				5A67DC29286946F800AC156C /* StudyView.swift */,
 				06A564D5289E9C5100DBC2E0 /* WordEditView.swift */,
-				068D4CFB28B2189300F44F6E /* WordBookCloseView.swift */,
+				068D4CFB28B2189300F44F6E /* WordMoveView.swift */,
 			);
 			path = Study;
 			sourceTree = "<group>";
@@ -694,7 +694,7 @@
 				5ACE0A7628699BAD00A57660 /* WordBook.swift in Sources */,
 				5AE7A76D28D981D9005E12B6 /* Date+Extension.swift in Sources */,
 				5AE1DB1C28C5D640006DB89C /* WordBookService.swift in Sources */,
-				068D4CFC28B2189300F44F6E /* WordBookCloseView.swift in Sources */,
+				068D4CFC28B2189300F44F6E /* WordMoveView.swift in Sources */,
 				5A67DC27286944FF00AC156C /* Size.swift in Sources */,
 				5A5740A828BDA8900080A2E2 /* Sample.swift in Sources */,
 				5A1FADFB28A1FC87000ACBD2 /* DataResettingScript.swift in Sources */,

--- a/JWords/iOSView/Study/StudyView.swift
+++ b/JWords/iOSView/Study/StudyView.swift
@@ -63,7 +63,7 @@ struct StudyView: View {
             ScrollView {
                 LazyVStack(spacing: 32) {
                     ForEach(viewModel.words, id: \.id) { word in
-                        WordCell(word: word, frontType: viewModel.frontType, eventPublisher: viewModel.eventPublisher)
+                        WordCell(word: word, frontType: viewModel.frontType, eventPublisher: viewModel.eventPublisher, isSelected: viewModel.isSelected(word))
                             .frame(width: deviceWidth * 0.9, height: word.hasImage ? 200 : 100)
                     }
                 }
@@ -179,6 +179,19 @@ extension StudyView {
                 eventPublisher.send(StudyViewEvent.toFront)
             }
         }
+        
+        // 선택해서 이동 기능 관련 variables
+        @Published var isSelectionMode: Bool = false
+        @Published var selectedWords: [Word] = []
+        
+        func isSelected(_ word: Word) -> Bool {
+            if isSelectionMode {
+                return selectedWords.contains(where: { $0.id == word.id })
+            } else {
+                return false
+            }
+        }
+        
         private(set) var eventPublisher = PassthroughSubject<Event, Never>()
         
         private let wordService: WordService

--- a/JWords/iOSView/Study/StudyView.swift
+++ b/JWords/iOSView/Study/StudyView.swift
@@ -173,6 +173,7 @@ extension StudyView {
         
         @ObservedObject private var viewModel: ViewModel
         private let word: Word
+        @State private var isSelected: Bool = false
         
         init(viewModel: ViewModel, word: Word) {
             self.viewModel = viewModel
@@ -181,24 +182,43 @@ extension StudyView {
         
         var body: some View {
             ZStack {
-                if viewModel.isSelected(word) {
-                    Color.black
-                        .opacity(0.5)
+                if !viewModel.isSelected(word) {
+                    Color.gray
+                        .opacity(0.2)
                 } else {
-                    HStack {
-                        Spacer()
-                        Image(systemName: "checkmark")
-                            .font(.largeTitle)
-                            .foregroundColor(.red)
-                    }
+                    Color.blue
+                        .opacity(0.2)
                 }
             }
-            .onTapGesture { OnTapInSelectionMode(word) }
+            .mask(
+                AnimatingEdge(isAnimating: $isSelected)
+            )
+            .onTapGesture {
+                viewModel.toggleSelection(word)
+                isSelected.toggle()
+            }
         }
         
-        
-        private func OnTapInSelectionMode(_ word: Word) {
-            // 뷰모델에서 토글 넣기
+        private struct AnimatingEdge: View {
+            @Binding private var isAnimating: Bool
+            @State private var dashPhase: CGFloat = 0
+            
+            init(isAnimating: Binding<Bool>) {
+                self._isAnimating = isAnimating
+            }
+            
+            var body: some View {
+                if isAnimating {
+                    Rectangle()
+                        .stroke(style: StrokeStyle(lineWidth: 5, lineCap: .round, dash: [10, 10], dashPhase: dashPhase))
+                        .animation(.linear.repeatForever(autoreverses: false).speed(1), value: dashPhase)
+                        .onAppear { dashPhase = -20 }
+                } else {
+                    Rectangle()
+                        .stroke(style: StrokeStyle(lineWidth: 5, lineCap: .round, dash: [10, 10], dashPhase: dashPhase))
+                        .onAppear { dashPhase = 0 }
+                }
+            }
         }
     }
 }

--- a/JWords/iOSView/Study/StudyView.swift
+++ b/JWords/iOSView/Study/StudyView.swift
@@ -66,7 +66,8 @@ struct StudyView: View {
                         ZStack {
                             WordCell(word: word, frontType: viewModel.frontType, eventPublisher: viewModel.eventPublisher)
                             if viewModel.isSelectionMode {
-                                SelectableCell(viewModel: viewModel, word: word)
+                                SelectableCell(isSelected: viewModel.isSelected(word))
+                                    .onTapGesture { viewModel.toggleSelection(word) }
                             }
                         }
                         .frame(width: deviceWidth * 0.9, height: word.hasImage ? 200 : 100)
@@ -172,19 +173,15 @@ extension StudyView {
     }
     
     private struct SelectableCell: View {
+        private let isSelected: Bool
         
-        @ObservedObject private var viewModel: ViewModel
-        private let word: Word
-        @State private var isSelected: Bool = false
-        
-        init(viewModel: ViewModel, word: Word) {
-            self.viewModel = viewModel
-            self.word = word
+        init(isSelected: Bool) {
+            self.isSelected = isSelected
         }
         
         var body: some View {
             ZStack {
-                if !viewModel.isSelected(word) {
+                if !isSelected {
                     Color.gray
                         .opacity(0.2)
                 } else {
@@ -193,20 +190,16 @@ extension StudyView {
                 }
             }
             .mask(
-                AnimatingEdge(isAnimating: $isSelected)
+                AnimatingEdge(isAnimating: isSelected)
             )
-            .onTapGesture {
-                viewModel.toggleSelection(word)
-                isSelected.toggle()
-            }
         }
         
         private struct AnimatingEdge: View {
-            @Binding private var isAnimating: Bool
+            private let isAnimating: Bool
             @State private var dashPhase: CGFloat = 0
             
-            init(isAnimating: Binding<Bool>) {
-                self._isAnimating = isAnimating
+            init(isAnimating: Bool) {
+                self.isAnimating = isAnimating
             }
             
             var body: some View {

--- a/JWords/iOSView/Study/StudyView.swift
+++ b/JWords/iOSView/Study/StudyView.swift
@@ -152,6 +152,8 @@ extension StudyView {
                     }
                     .pickerStyle(.segmented)
                     .padding()
+                    Toggle("선택 모드", isOn: $viewModel.isSelectionMode)
+                        .padding()
                     Spacer()
                 }
                 .frame(width: Constants.Size.deviceWidth * 0.7)
@@ -239,7 +241,12 @@ extension StudyView {
         }
         
         // 선택해서 이동 기능 관련 variables
-        @Published private(set) var isSelectionMode: Bool = true
+        @Published var isSelectionMode: Bool = false {
+            didSet {
+                eventPublisher.send(StudyViewEvent.toFront)
+                selectionDict = [String : Bool]()
+            }
+        }
         @Published private(set) var selectionDict = [String : Bool]()
         
         func isSelected(_ word: Word) -> Bool {

--- a/JWords/iOSView/Study/StudyView.swift
+++ b/JWords/iOSView/Study/StudyView.swift
@@ -259,7 +259,11 @@ extension StudyView {
         }
         
         var toMoveWords: [Word] {
-            _words.filter { $0.studyState != .success }
+            if !isSelectionMode {
+                return _words.filter { $0.studyState != .success }
+            } else {
+                return _words.filter { selectionDict[$0.id, default: false] }
+            }
         }
         
         init(wordBook: WordBook, wordService: WordService) {

--- a/JWords/iOSView/Study/StudyView.swift
+++ b/JWords/iOSView/Study/StudyView.swift
@@ -104,7 +104,7 @@ struct StudyView: View {
         }
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
-                Button("마감") { showCloseModal = true }
+                Button(viewModel.isSelectionMode ? "이동" : "마감") { showCloseModal = true }
                     .disabled(viewModel.wordBook == nil)
             }
         }

--- a/JWords/iOSView/Study/StudyView.swift
+++ b/JWords/iOSView/Study/StudyView.swift
@@ -43,7 +43,7 @@ struct StudyView: View {
     
     @State private var deviceWidth: CGFloat = Constants.Size.deviceWidth
     @State private var showEditModal: Bool = false
-    @State private var showCloseModal: Bool = false
+    @State private var showMoveModal: Bool = false
     @State private var shouldDismiss: Bool = false
     @State private var showSideBar: Bool = false
     
@@ -83,8 +83,8 @@ struct StudyView: View {
             viewModel.fetchWords()
             resetDeviceWidth()
         }
-        .sheet(isPresented: $showCloseModal, onDismiss: { if shouldDismiss { dismiss() } }) {
-            WordBookCloseView(wordBook: viewModel.wordBook!, toMoveWords: viewModel.toMoveWords, didClosed: $shouldDismiss, dependency: dependency)
+        .sheet(isPresented: $showMoveModal, onDismiss: { if shouldDismiss { dismiss() } }) {
+            WordMoveView(wordBook: viewModel.wordBook!, toMoveWords: viewModel.toMoveWords, didClosed: $shouldDismiss, dependency: dependency)
         }
         #if os(iOS)
         // TODO: 화면 돌리면 알아서 다시 deviceWidth를 전달해서 cell 크기를 다시 계산한다.
@@ -104,7 +104,7 @@ struct StudyView: View {
         }
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
-                Button(viewModel.isSelectionMode ? "이동" : "마감") { showCloseModal = true }
+                Button(viewModel.isSelectionMode ? "이동" : "마감") { showMoveModal = true }
                     .disabled(viewModel.wordBook == nil)
             }
         }

--- a/JWords/iOSView/Study/WordBookCloseView.swift
+++ b/JWords/iOSView/Study/WordBookCloseView.swift
@@ -26,7 +26,7 @@ struct WordBookCloseView: View {
                     .scaleEffect(5)
             }
             VStack {
-                Text("\(viewModel.toMoveWords.count)개의 틀린 단어들을 이동할 단어장을 골라주세요.")
+                Text("\(viewModel.toMoveWords.count)개의 단어들을 이동할 단어장을 골라주세요.")
                 Picker("이동할 단어장 고르기", selection: $viewModel.selectedID) {
                     Text(viewModel.wordBooks.isEmpty ? "로딩중" : "이동 안함")
                         .tag(nil as String?)

--- a/JWords/iOSView/Study/WordMoveView.swift
+++ b/JWords/iOSView/Study/WordMoveView.swift
@@ -13,7 +13,7 @@ struct WordMoveView: View {
     @Binding private var didClosed: Bool
     
     init(wordBook: WordBook, toMoveWords: [Word], didClosed: Binding<Bool>, dependency: Dependency) {
-        self.viewModel = ViewModel(toClose: wordBook, toMoveWords: toMoveWords, dependency: dependency)
+        self.viewModel = ViewModel(fromBook: wordBook, toMoveWords: toMoveWords, dependency: dependency)
         self._didClosed = didClosed
         // FIXME: 이 API 호출은 3번 실행됨. (Modal이 3번 init되기 때문)
         viewModel.getWordBooks()
@@ -59,7 +59,7 @@ struct WordMoveView: View {
 
 extension WordMoveView {
     final class ViewModel: ObservableObject {
-        private let toClose: WordBook
+        private let fromBook: WordBook
         let toMoveWords: [Word]
         private let wordBookService: WordBookService
         private let todayService: TodayService
@@ -76,8 +76,8 @@ extension WordMoveView {
             }
         }
         
-        init(toClose: WordBook, toMoveWords: [Word], dependency: Dependency) {
-            self.toClose = toClose
+        init(fromBook: WordBook, toMoveWords: [Word], dependency: Dependency) {
+            self.fromBook = fromBook
             self.toMoveWords = toMoveWords
             self.wordBookService = dependency.wordBookService
             self.todayService = dependency.todayService
@@ -95,14 +95,14 @@ extension WordMoveView {
                     return
                 }
                 
-                self?.wordBooks = books.filter { $0.closed != true && $0.id != self?.toClose.id }
+                self?.wordBooks = books.filter { $0.closed != true && $0.id != self?.fromBook.id }
             }
         }
         
         func moveWords(completionHandler: @escaping () -> Void) {
-            todayService.updateReviewed(toClose.id)
+            todayService.updateReviewed(fromBook.id)
             isClosing = true
-            wordBookService.moveWords(of: toClose, to: selectedWordBook, toMove: toMoveWords) { error in
+            wordBookService.moveWords(of: fromBook, to: selectedWordBook, toMove: toMoveWords) { error in
                 // TODO: Handle Error
                 if let error = error {
                     print(error)

--- a/JWords/iOSView/Study/WordMoveView.swift
+++ b/JWords/iOSView/Study/WordMoveView.swift
@@ -1,5 +1,5 @@
 //
-//  WordBookCloseView.swift
+//  WordMoveView.swift
 //  JWords
 //
 //  Created by JW Moon on 2022/08/21.
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct WordBookCloseView: View {
+struct WordMoveView: View {
     @ObservedObject private var viewModel: ViewModel
     @Environment(\.dismiss) private var dismiss
     @Binding private var didClosed: Bool
@@ -44,7 +44,7 @@ struct WordBookCloseView: View {
                         dismiss()
                     }
                     Button(viewModel.selectedID != nil ? "이동" : "닫기") {
-                        viewModel.closeBook {
+                        viewModel.moveWords {
                             didClosed = true
                             dismiss()
                         }
@@ -57,7 +57,7 @@ struct WordBookCloseView: View {
     
 }
 
-extension WordBookCloseView {
+extension WordMoveView {
     final class ViewModel: ObservableObject {
         private let toClose: WordBook
         let toMoveWords: [Word]
@@ -99,7 +99,7 @@ extension WordBookCloseView {
             }
         }
         
-        func closeBook(completionHandler: @escaping () -> Void) {
+        func moveWords(completionHandler: @escaping () -> Void) {
             todayService.updateReviewed(toClose.id)
             isClosing = true
             wordBookService.moveWords(of: toClose, to: selectedWordBook, toMove: toMoveWords) { error in

--- a/JWords/iOSView/items/WordCell.swift
+++ b/JWords/iOSView/items/WordCell.swift
@@ -14,7 +14,6 @@ struct WordCell: View {
     @ObservedObject private var viewModel: ViewModel
     @GestureState private var dragAmount = CGSize.zero
     @State private var isFront = true
-    @State private var isSelected: Bool
     
     // MARK: Gestures
     private var dragGesture: some Gesture {
@@ -34,9 +33,8 @@ struct WordCell: View {
     }
     
     // MARK: Initializer
-    init(word: Word, frontType: FrontType, eventPublisher: PassthroughSubject<Event, Never>, isSelected: Bool) {
+    init(word: Word, frontType: FrontType, eventPublisher: PassthroughSubject<Event, Never>) {
         self.viewModel = ViewModel(word: word, frontType: frontType, eventPublisher: eventPublisher)
-        self.isSelected = isSelected
         viewModel.prefetchImage()
     }
     
@@ -50,14 +48,6 @@ struct WordCell: View {
                 .gesture(tapGesture)
                 // TODO: show WordEditView
                 .onLongPressGesture { }
-            if isSelected == true {
-                HStack {
-                    Spacer()
-                    Image(systemName: "checkmark")
-                        .font(.largeTitle)
-                        .foregroundColor(.red)
-                }
-            }
         }
     }
 }

--- a/JWords/iOSView/items/WordCell.swift
+++ b/JWords/iOSView/items/WordCell.swift
@@ -14,6 +14,7 @@ struct WordCell: View {
     @ObservedObject private var viewModel: ViewModel
     @GestureState private var dragAmount = CGSize.zero
     @State private var isFront = true
+    @State private var isSelected: Bool
     
     // MARK: Gestures
     private var dragGesture: some Gesture {
@@ -33,20 +34,31 @@ struct WordCell: View {
     }
     
     // MARK: Initializer
-    init(word: Word, frontType: FrontType, eventPublisher: PassthroughSubject<Event, Never>) {
+    init(word: Word, frontType: FrontType, eventPublisher: PassthroughSubject<Event, Never>, isSelected: Bool) {
         self.viewModel = ViewModel(word: word, frontType: frontType, eventPublisher: eventPublisher)
+        self.isSelected = isSelected
         viewModel.prefetchImage()
     }
     
     // MARK: Body
     var body: some View {
-        ContentView(isFront: isFront, viewModel: viewModel, cellFaceOffset: dragAmount)
-            .onReceive(viewModel.eventPublisher) { handleEvent($0) }
-            .gesture(dragGesture)
-            .gesture(doubleTapGesture)
-            .gesture(tapGesture)
-            // TODO: show WordEditView
-            .onLongPressGesture { }
+        ZStack {
+            ContentView(isFront: isFront, viewModel: viewModel, cellFaceOffset: dragAmount)
+                .onReceive(viewModel.eventPublisher) { handleEvent($0) }
+                .gesture(dragGesture)
+                .gesture(doubleTapGesture)
+                .gesture(tapGesture)
+                // TODO: show WordEditView
+                .onLongPressGesture { }
+            if isSelected == true {
+                HStack {
+                    Spacer()
+                    Image(systemName: "checkmark")
+                        .font(.largeTitle)
+                        .foregroundColor(.red)
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
# 선택한 단어를 다른 단어장으로 이동하는 기능
## 기능 소개
선택 모드로 들어가서 단어들을 선택하고 선택된 단어들을 다른 단어장으로 이동할 수 있음.
![선택해서 이동 기능](https://user-images.githubusercontent.com/70995840/197667543-4d18735d-14d0-4ed4-a51f-b80a98f07159.gif)
## 선택된 Cell 애니메이션 구현
[블로그 포스팅](https://velog.io/@comdongsam/%EC%84%A0%ED%83%9D%EB%90%9C-Cell%EC%97%90%EB%A7%8C-%EC%95%A0%EB%8B%88%EB%A9%94%EC%9D%B4%EC%85%98-%EC%A0%81%EC%9A%A9-%ED%95%B4%EB%B3%B4%EA%B8%B0) 참고
## ViewModel에 이동 구현
Dictionary 활용해서 구현
```swift
// 단어 선택 모드 
@Published var isSelectionMode: Bool = false {
    didSet {
        eventPublisher.send(StudyViewEvent.toFront)
        selectionDict = [String : Bool]()
    }
}

// 선택된 단어들을 저장하는 Dict
@Published private(set) var selectionDict = [String : Bool]()

// 해당 단어가 선택되었는지 확인하는 함수
func isSelected(_ word: Word) -> Bool {
    selectionDict[word.id, default: false]
}

// 해당 단어의 선택 여부를 toggle하는 함수
func toggleSelection(_ word: Word) {
    selectionDict[word.id, default: false].toggle()
}

// 이동할 단어의 Array를 리턴하는 함수
var toMoveWords: [Word] {
    if !isSelectionMode {
        return _words.filter { $0.studyState != .success }
    } else {
        return _words.filter { selectionDict[$0.id, default: false] }
    }
}
```
## 단어 이동 로직
[단어장 마감 PR 참고](https://github.com/SteadySlower/JWords/pull/30)
