### PR TITLE
[Feature] TodayService from memory to Firebase

### DIFF
--- a/JWords.xcodeproj/project.pbxproj
+++ b/JWords.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		5A6082EC28D299A70031E983 /* Quick in Frameworks */ = {isa = PBXBuildFile; productRef = 5A6082EB28D299A70031E983 /* Quick */; settings = {ATTRIBUTES = (Required, ); }; };
 		5A6082EE28D299AC0031E983 /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = 5A6082ED28D299AC0031E983 /* Nimble */; };
 		5A616D9F28C05A0E0013B5AE /* Database.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A616D9E28C05A0E0013B5AE /* Database.swift */; };
+		5A653FEB2907C1C800E3466E /* TodayBooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A653FEA2907C1C800E3466E /* TodayBooks.swift */; };
 		5A67DC1C2869426600AC156C /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 5A67DC1B2869426500AC156C /* GoogleService-Info.plist */; };
 		5A67DC20286942FE00AC156C /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A67DC1F286942FE00AC156C /* HomeView.swift */; };
 		5A67DC23286943A900AC156C /* HomeCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A67DC22286943A800AC156C /* HomeCell.swift */; };
@@ -139,6 +140,7 @@
 		5A5FF62E286A8F68000150A7 /* ImageUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUploader.swift; sourceTree = "<group>"; };
 		5A5FF631286AD79E000150A7 /* ImageCompressor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCompressor.swift; sourceTree = "<group>"; };
 		5A616D9E28C05A0E0013B5AE /* Database.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Database.swift; sourceTree = "<group>"; };
+		5A653FEA2907C1C800E3466E /* TodayBooks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayBooks.swift; sourceTree = "<group>"; };
 		5A67DC1B2869426500AC156C /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		5A67DC1F286942FE00AC156C /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		5A67DC22286943A800AC156C /* HomeCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCell.swift; sourceTree = "<group>"; };
@@ -486,6 +488,7 @@
 				0697715228CCA71700569280 /* WordInput.swift */,
 				5AD8070A28A0EDE300ADB6F7 /* Events.swift */,
 				5A5740A728BDA8900080A2E2 /* Sample.swift */,
+				5A653FEA2907C1C800E3466E /* TodayBooks.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -697,6 +700,7 @@
 				068D4CFC28B2189300F44F6E /* WordMoveView.swift in Sources */,
 				5A67DC27286944FF00AC156C /* Size.swift in Sources */,
 				5A5740A828BDA8900080A2E2 /* Sample.swift in Sources */,
+				5A653FEB2907C1C800E3466E /* TodayBooks.swift in Sources */,
 				5A1FADFB28A1FC87000ACBD2 /* DataResettingScript.swift in Sources */,
 				5AE1DB1A28C5D51B006DB89C /* SampleService.swift in Sources */,
 				5A67DC2D2869470C00AC156C /* WordCell.swift in Sources */,

--- a/JWords/API/Database.swift
+++ b/JWords/API/Database.swift
@@ -64,11 +64,10 @@ final class FirestoreDB: Database {
         .collection("examples")
     }()
     
-    private lazy var todayRef = {
+    private lazy var dataRef = {
         firestore
         .collection("develop")
         .document("data")
-        .collection("today")
     }()
 }
 
@@ -295,14 +294,15 @@ extension FirestoreDB {
     }
     
     func updateTodayBooks(_ todayBooks: TodayBooks, _ completionHandler: @escaping CompletionWithoutData) {
+        
         let data: [String : Any] = [
             "studyIDs": todayBooks.studyIDs,
             "reviewIDs": todayBooks.reviewIDs,
-            "timestamp": todayBooks.createdAt,
-            "reviewedIDs": todayBooks.reviewIDs
+            "timestamp": Timestamp(date: todayBooks.createdAt),
+            "reviewedIDs": todayBooks.reviewedIDs
         ]
         
-        todayRef.addDocument(data: data) { error in
+        dataRef.updateData(["today" : data]) { error in
             if error != nil {
                 completionHandler(error)
                 return

--- a/JWords/API/Database.swift
+++ b/JWords/API/Database.swift
@@ -290,7 +290,32 @@ extension FirestoreDB {
 
 extension FirestoreDB {
     func getTodayBooks(_ completionHandler: @escaping CompletionWithData<TodayBooks>) {
-        
+        dataRef.getDocument { snapshot, error in
+            if let error = error {
+                completionHandler(nil, error)
+                return
+            }
+            guard var dict = snapshot?.data()?["today"] as? [String: Any] else {
+                let error = AppError.Firebase.noDocument
+                completionHandler(nil, error)
+                return
+            }
+            
+            guard let timestamp = dict["timestamp"] as? Timestamp else {
+                let error = AppError.Firebase.noTimestamp
+                completionHandler(nil, error)
+                return
+            }
+            
+            dict["createdAt"] = timestamp.dateValue()
+            
+            do {
+                let todayBooks = try TodayBooksImpl(dict: dict)
+                completionHandler(todayBooks, nil)
+            } catch let error {
+                completionHandler(nil, error)
+            }
+        }
     }
     
     func updateTodayBooks(_ todayBooks: TodayBooks, _ completionHandler: @escaping CompletionWithoutData) {

--- a/JWords/API/Database.swift
+++ b/JWords/API/Database.swift
@@ -27,12 +27,8 @@ protocol Database {
     func updateUsed(of sample: Sample, to used: Int)
     
     // Today 관련
-    func updateTodayStudy(_ idArray: [String], _ completionHandler: @escaping CompletionWithoutData)
-    func getTodayStudy(_ completionHandler: @escaping CompletionWithData<[String]>)
-    func updateTodayReview(_ idArray: [String], _ completionHandler: @escaping CompletionWithoutData)
-    func getTodayReview(_ completionHandler: @escaping CompletionWithData<[String]>)
-    func updateTodaySchedule(toStudyIDs: [String], toReviewIDs: [String], _ completionHandler: @escaping CompletionWithData<([String], [String])>)
-    func updateReviewed(_ id: String)
+    func getTodayBooks(_ completionHandler: @escaping CompletionWithData<TodayBooks>)
+    func updateTodayBooks(_ todayBooks: TodayBooks, _ completionHandler: @escaping CompletionWithoutData)
 }
 
 // Firebase에 직접 extension으로 만들어도 되지만 Firebase를 한단계 감싼 class를 만들었음.
@@ -294,27 +290,24 @@ extension FirestoreDB {
 //MARK: TodayDatebase
 
 extension FirestoreDB {
-    func updateTodayStudy(_ idArray: [String], _ completionHandler: @escaping CompletionWithoutData) {
+    func getTodayBooks(_ completionHandler: @escaping CompletionWithData<TodayBooks>) {
         
     }
     
-    func getTodayStudy(_ completionHandler: @escaping CompletionWithData<[String]>) {
+    func updateTodayBooks(_ todayBooks: TodayBooks, _ completionHandler: @escaping CompletionWithoutData) {
+        let data: [String : Any] = [
+            "studyIDs": todayBooks.studyIDs,
+            "reviewIDs": todayBooks.reviewIDs,
+            "timestamp": todayBooks.createdAt,
+            "reviewedIDs": todayBooks.reviewIDs
+        ]
         
-    }
-    
-    func updateTodayReview(_ idArray: [String], _ completionHandler: @escaping CompletionWithoutData) {
-        
-    }
-    
-    func getTodayReview(_ completionHandler: @escaping CompletionWithData<[String]>) {
-        
-    }
-    
-    func updateTodaySchedule(toStudyIDs: [String], toReviewIDs: [String], _ completionHandler: @escaping CompletionWithData<([String], [String])>) {
-        
-    }
-    
-    func updateReviewed(_ id: String) {
-        
+        todayRef.addDocument(data: data) { error in
+            if error != nil {
+                completionHandler(error)
+                return
+            }
+            completionHandler(nil)
+        }
     }
 }

--- a/JWords/API/Database.swift
+++ b/JWords/API/Database.swift
@@ -59,6 +59,13 @@ final class FirestoreDB: Database {
         .document("data")
         .collection("examples")
     }()
+    
+    private lazy var todayRef = {
+        firestore
+        .collection("develop")
+        .document("data")
+        .collection("today")
+    }()
 }
 
 

--- a/JWords/API/Database.swift
+++ b/JWords/API/Database.swift
@@ -296,8 +296,8 @@ extension FirestoreDB {
                 return
             }
             guard var dict = snapshot?.data()?["today"] as? [String: Any] else {
-                let error = AppError.Firebase.noDocument
-                completionHandler(nil, error)
+                let emptyTodayBooks = TodayBooksImpl(studyIDs: [], reviewIDs: [], reviewedIDs: [], createdAt: Date())
+                completionHandler(emptyTodayBooks, nil)
                 return
             }
             

--- a/JWords/API/Database.swift
+++ b/JWords/API/Database.swift
@@ -31,7 +31,7 @@ protocol Database {
     func getTodayStudy(_ completionHandler: @escaping CompletionWithData<[String]>)
     func updateTodayReview(_ idArray: [String], _ completionHandler: @escaping CompletionWithoutData)
     func getTodayReview(_ completionHandler: @escaping CompletionWithData<[String]>)
-    func updateTodaySchedule(_ wordBooks: [WordBook], _ completionHandler: @escaping CompletionWithData<([String], [String])>)
+    func updateTodaySchedule(toStudyIDs: [String], toReviewIDs: [String], _ completionHandler: @escaping CompletionWithData<([String], [String])>)
     func updateReviewed(_ id: String)
 }
 
@@ -310,7 +310,7 @@ extension FirestoreDB {
         
     }
     
-    func updateTodaySchedule(_ wordBooks: [WordBook], _ completionHandler: @escaping CompletionWithData<([String], [String])>) {
+    func updateTodaySchedule(toStudyIDs: [String], toReviewIDs: [String], _ completionHandler: @escaping CompletionWithData<([String], [String])>) {
         
     }
     

--- a/JWords/API/Database.swift
+++ b/JWords/API/Database.swift
@@ -25,6 +25,14 @@ protocol Database {
     func insertSample(_ wordInput: WordInput)
     func fetchSample(_ query: String, completionHandler: @escaping CompletionWithData<[Sample]>)
     func updateUsed(of sample: Sample, to used: Int)
+    
+    // Today 관련
+    func updateTodayStudy(_ idArray: [String], _ completionHandler: @escaping CompletionWithoutData)
+    func getTodayStudy(_ completionHandler: @escaping CompletionWithData<[String]>)
+    func updateTodayReview(_ idArray: [String], _ completionHandler: @escaping CompletionWithoutData)
+    func getTodayReview(_ completionHandler: @escaping CompletionWithData<[String]>)
+    func updateTodaySchedule(_ wordBooks: [WordBook], _ completionHandler: @escaping CompletionWithData<([String], [String])>)
+    func updateReviewed(_ id: String)
 }
 
 // Firebase에 직접 extension으로 만들어도 되지만 Firebase를 한단계 감싼 class를 만들었음.
@@ -280,5 +288,33 @@ extension FirestoreDB {
     
     func updateUsed(of sample: Sample, to used: Int) {
         sampleRef.document(sample.id).updateData(["used" : used])
+    }
+}
+
+//MARK: TodayDatebase
+
+extension FirestoreDB {
+    func updateTodayStudy(_ idArray: [String], _ completionHandler: @escaping CompletionWithoutData) {
+        
+    }
+    
+    func getTodayStudy(_ completionHandler: @escaping CompletionWithData<[String]>) {
+        
+    }
+    
+    func updateTodayReview(_ idArray: [String], _ completionHandler: @escaping CompletionWithoutData) {
+        
+    }
+    
+    func getTodayReview(_ completionHandler: @escaping CompletionWithData<[String]>) {
+        
+    }
+    
+    func updateTodaySchedule(_ wordBooks: [WordBook], _ completionHandler: @escaping CompletionWithData<([String], [String])>) {
+        
+    }
+    
+    func updateReviewed(_ id: String) {
+        
     }
 }

--- a/JWords/DataService/TodaySerivce.swift
+++ b/JWords/DataService/TodaySerivce.swift
@@ -8,11 +8,8 @@
 import Foundation
 
 protocol TodayService {
-    func updateStudyBooks(_ idArray: [String], completionHandler: @escaping CompletionWithoutData)
-    func getStudyBooks(_ completionHandler: @escaping CompletionWithData<[String]>)
-    func updateReviewBooks(_ idArray: [String], completionHandler: @escaping CompletionWithoutData)
-    func getReviewBooks(_ completionHandler: @escaping CompletionWithData<[String]>)
-    func getTodaysBooks(_ wordBooks: [WordBook], _ completionHandler: @escaping CompletionWithData<([String], [String])>)
+    func autoUpdateTodayBooks(_ wordBooks: [WordBook], _ completionHandler: @escaping CompletionWithoutData)
+    func getTodayBooks(_ completionHandler: @escaping CompletionWithData<TodayBooks>)
     func updateReviewed(_ id: String)
 }
 
@@ -27,20 +24,17 @@ final class TodayServiceImpl: TodayService {
     }
     
     // functions
-    
-    func updateStudyBooks(_ idArray: [String], completionHandler: @escaping CompletionWithoutData) {
+    func getTodayBooks(_ completionHandler: @escaping CompletionWithData<TodayBooks>) {
+        db.getTodayBooks { todayBooks, error in
+            if error != nil {
+                completionHandler(nil, error)
+                return
+            }
+            completionHandler(todayBooks, nil)
+        }
     }
     
-    func getStudyBooks(_ completionHandler: @escaping CompletionWithData<[String]>) {
-    }
-    
-    func updateReviewBooks(_ idArray: [String], completionHandler: @escaping CompletionWithoutData) {
-    }
-    
-    func getReviewBooks(_ completionHandler: @escaping CompletionWithData<[String]>) {
-    }
-    
-    func getTodaysBooks(_ wordBooks: [WordBook], _ completionHandler: @escaping CompletionWithData<([String], [String])>) {
+    func autoUpdateTodayBooks(_ wordBooks: [WordBook], _ completionHandler: @escaping CompletionWithoutData) {
         var studyID = [String]()
         var reviewID = [String]()
         for wordBook in wordBooks {
@@ -53,7 +47,7 @@ final class TodayServiceImpl: TodayService {
         let todayBooks = TodayBooksImpl(studyIDs: studyID, reviewIDs: reviewID, reviewedIDs: [], createdAt: Date())
         
         db.updateTodayBooks(todayBooks) { error in
-            completionHandler(nil, nil)
+            completionHandler(error)
         }
     }
     

--- a/JWords/DataService/TodaySerivce.swift
+++ b/JWords/DataService/TodaySerivce.swift
@@ -8,9 +8,10 @@
 import Foundation
 
 protocol TodayService {
-    func autoUpdateTodayBooks(_ wordBooks: [WordBook], _ completionHandler: @escaping CompletionWithoutData)
     func getTodayBooks(_ completionHandler: @escaping CompletionWithData<TodayBooks>)
+    func autoUpdateTodayBooks(_ wordBooks: [WordBook], _ completionHandler: @escaping CompletionWithoutData)
     func updateTodayBooks(_ todayBooks: TodayBooks, _ completionHandler: @escaping CompletionWithoutData)
+    func updateReviewed(_ reviewedID: String, _ completionHandler: @escaping CompletionWithoutData)
 }
 
 final class TodayServiceImpl: TodayService {
@@ -53,5 +54,22 @@ final class TodayServiceImpl: TodayService {
     
     func updateTodayBooks(_ todayBooks: TodayBooks, _ completionHandler: @escaping CompletionWithoutData) {
         db.updateTodayBooks(todayBooks, completionHandler)
+    }
+    
+    func updateReviewed(_ reviewedID: String, _ completionHandler: @escaping CompletionWithoutData) {
+        getTodayBooks { [weak self] todayBooks, error in
+            guard let self = self else { return }
+            if let error = error {
+                completionHandler(error)
+                return
+            }
+            // TODO: Handle Error
+            guard let todayBooks = todayBooks else { return }
+            let newReviewedIDs = todayBooks.reviewedIDs + [reviewedID]
+            let newTodayBooks = TodayBooksImpl(studyIDs: todayBooks.studyIDs, reviewIDs: todayBooks.reviewIDs, reviewedIDs: newReviewedIDs, createdAt: todayBooks.createdAt)
+            self.updateTodayBooks(newTodayBooks) { error in
+                completionHandler(error)
+            }
+        }
     }
 }

--- a/JWords/DataService/TodaySerivce.swift
+++ b/JWords/DataService/TodaySerivce.swift
@@ -5,6 +5,8 @@
 //  Created by Jong Won Moon on 2022/09/19.
 //
 
+import Foundation
+
 protocol TodayService {
     func updateStudyBooks(_ idArray: [String], completionHandler: @escaping CompletionWithoutData)
     func getStudyBooks(_ completionHandler: @escaping CompletionWithData<[String]>)
@@ -24,29 +26,18 @@ final class TodayServiceImpl: TodayService {
         self.db = database
     }
     
-    private var studyID = [String]()
-    private var reviewID = [String]()
-    private var reviewedID = [String]()
-    
     // functions
     
     func updateStudyBooks(_ idArray: [String], completionHandler: @escaping CompletionWithoutData) {
-        self.studyID = idArray
-        completionHandler(nil)
     }
     
     func getStudyBooks(_ completionHandler: @escaping CompletionWithData<[String]>) {
-        completionHandler(studyID, nil)
     }
     
     func updateReviewBooks(_ idArray: [String], completionHandler: @escaping CompletionWithoutData) {
-        self.reviewID = idArray
-        completionHandler(nil)
     }
     
     func getReviewBooks(_ completionHandler: @escaping CompletionWithData<[String]>) {
-        let filtered = reviewID.filter { !reviewedID.contains($0) }
-        completionHandler(filtered, nil)
     }
     
     func getTodaysBooks(_ wordBooks: [WordBook], _ completionHandler: @escaping CompletionWithData<([String], [String])>) {
@@ -59,13 +50,13 @@ final class TodayServiceImpl: TodayService {
                 reviewID.append(wordBook.id)
             }
         }
-        self.studyID = studyID
-        self.reviewID = reviewID
-        self.reviewedID = [String]()
-        completionHandler((studyID, reviewID), nil)
+        let todayBooks = TodayBooksImpl(studyIDs: studyID, reviewIDs: reviewID, reviewedIDs: [], createdAt: Date())
+        
+        db.updateTodayBooks(todayBooks) { error in
+            completionHandler(nil, nil)
+        }
     }
     
     func updateReviewed(_ id: String) {
-        reviewedID.append(id)
     }
 }

--- a/JWords/DataService/TodaySerivce.swift
+++ b/JWords/DataService/TodaySerivce.swift
@@ -14,10 +14,21 @@ protocol TodayService {
     func updateReviewed(_ id: String)
 }
 
-class TodayServiceImpl: TodayService {
+final class TodayServiceImpl: TodayService {
+    
+    // DB
+    let db: Database
+    
+    // Initializer
+    init(database: Database) {
+        self.db = database
+    }
+    
     private var studyID = [String]()
     private var reviewID = [String]()
     private var reviewedID = [String]()
+    
+    // functions
     
     func updateStudyBooks(_ idArray: [String], completionHandler: @escaping CompletionWithoutData) {
         self.studyID = idArray

--- a/JWords/DataService/TodaySerivce.swift
+++ b/JWords/DataService/TodaySerivce.swift
@@ -10,7 +10,7 @@ import Foundation
 protocol TodayService {
     func autoUpdateTodayBooks(_ wordBooks: [WordBook], _ completionHandler: @escaping CompletionWithoutData)
     func getTodayBooks(_ completionHandler: @escaping CompletionWithData<TodayBooks>)
-    func updateReviewed(_ id: String)
+    func updateTodayBooks(_ todayBooks: TodayBooks, _ completionHandler: @escaping CompletionWithoutData)
 }
 
 final class TodayServiceImpl: TodayService {
@@ -51,6 +51,7 @@ final class TodayServiceImpl: TodayService {
         }
     }
     
-    func updateReviewed(_ id: String) {
+    func updateTodayBooks(_ todayBooks: TodayBooks, _ completionHandler: @escaping CompletionWithoutData) {
+        db.updateTodayBooks(todayBooks, completionHandler)
     }
 }

--- a/JWords/Helper/Dependency.swift
+++ b/JWords/Helper/Dependency.swift
@@ -30,7 +30,7 @@ class DependencyImpl: Dependency {
         self.wordService = WordServiceImpl(database: db, imageUploader: iu)
         self.wordBookService = WordBookServiceImpl(database: db, wordService: wordService)
         self.sampleService = SampleServiceImpl(database: db)
-        self.todayService = TodayServiceImpl()
+        self.todayService = TodayServiceImpl(database: db)
     }
     
 

--- a/JWords/Helper/Error.swift
+++ b/JWords/Helper/Error.swift
@@ -51,6 +51,7 @@ enum AppError: Error {
         case wordBookImpl
         case wordImpl
         case sampleImpl
+        case todayBookImpl
         
         var message: String {
             return "\(String(describing: self)): Failed to init \(self.rawValue)"

--- a/JWords/Model/TodayBooks.swift
+++ b/JWords/Model/TodayBooks.swift
@@ -31,7 +31,7 @@ struct TodayBooksImpl: TodayBooks {
         
         if let studyIDs = dict["studyIDs"] as? [String],
            let reviewIDs = dict["reviewIDs"] as? [String],
-           let reviewedIDs = dict["reviewIDs"] as? [String],
+           let reviewedIDs = dict["reviewedIDs"] as? [String],
            let createdAt = dict["createdAt"] as? Date
         {
             self.studyIDs = studyIDs

--- a/JWords/Model/TodayBooks.swift
+++ b/JWords/Model/TodayBooks.swift
@@ -1,0 +1,45 @@
+//
+//  TodayBooks.swift
+//  JWords
+//
+//  Created by Jong Won Moon on 2022/10/25.
+//
+
+import Foundation
+
+protocol TodayBooks {
+    var studyIDs: [String] { get }
+    var reviewIDs: [String] { get }
+    var reviewedIDs: [String] { get }
+    var createdAt: Date { get }
+}
+
+struct TodayBooksImpl: TodayBooks {
+    let studyIDs: [String]
+    let reviewIDs: [String]
+    let reviewedIDs: [String]
+    let createdAt: Date
+    
+    init(studyIDs: [String], reviewIDs: [String], reviewedIDs: [String], createdAt: Date) {
+        self.studyIDs = studyIDs
+        self.reviewIDs = reviewIDs
+        self.reviewedIDs = reviewedIDs
+        self.createdAt = createdAt
+    }
+    
+    init(dict: [String: Any]) throws {
+        
+        if let studyIDs = dict["studyIDs"] as? [String],
+           let reviewIDs = dict["reviewIDs"] as? [String],
+           let reviewedIDs = dict["reviewIDs"] as? [String],
+           let createdAt = dict["createdAt"] as? Date
+        {
+            self.studyIDs = studyIDs
+            self.reviewIDs = reviewIDs
+            self.reviewedIDs = reviewedIDs
+            self.createdAt = createdAt
+        } else {
+            throw AppError.Initializer.todayBookImpl
+        }
+    }
+}

--- a/JWords/iOSView/Study/WordMoveView.swift
+++ b/JWords/iOSView/Study/WordMoveView.swift
@@ -99,7 +99,7 @@ extension WordMoveView {
             }
         }
         
-        // TODO: Handle Error
+        // TODO: Handle Error + reduce callbacks
         func moveWords(completionHandler: @escaping () -> Void) {
             isClosing = true
             

--- a/JWords/iOSView/Study/WordMoveView.swift
+++ b/JWords/iOSView/Study/WordMoveView.swift
@@ -99,25 +99,23 @@ extension WordMoveView {
             }
         }
         
-        // TODO: Handle Error + reduce callbacks
+        // TODO: Handle Error
         func moveWords(completionHandler: @escaping () -> Void) {
             isClosing = true
             
-            todayService.getTodayBooks { [weak self] todayBooks, error in
+            todayService.updateReviewed(fromBook.id) { [weak self] error in
                 guard let self = self else { return }
-                if let error = error { print(error); return }
-                guard let todayBooks = todayBooks else { return }
-                let newReviewedIDs = todayBooks.reviewedIDs + [self.fromBook.id]
-                let newTodayBooks = TodayBooksImpl(studyIDs: todayBooks.studyIDs, reviewIDs: todayBooks.reviewIDs, reviewedIDs: newReviewedIDs, createdAt: Date())
-                self.todayService.updateTodayBooks(newTodayBooks) { error in
-                    if let error = error { print(error); return }
-                    self.wordBookService.moveWords(of: self.fromBook, to: self.selectedWordBook, toMove: self.toMoveWords) { error in
-                        if let error = error {
-                            print(error)
-                            return
-                        }
-                        completionHandler()
+                if let error = error {
+                    print(error)
+                    return
+                }
+                
+                self.wordBookService.moveWords(of: self.fromBook, to: self.selectedWordBook, toMove: self.toMoveWords) { error in
+                    if let error = error {
+                        print(error)
+                        return
                     }
+                    completionHandler()
                 }
             }
         }

--- a/JWords/iOSView/Today/TodaySelectionModal.swift
+++ b/JWords/iOSView/Today/TodaySelectionModal.swift
@@ -146,6 +146,8 @@ extension TodaySelectionModal {
                     for reviewID in todayBooks.reviewIDs {
                         self.schedules[reviewID] = .review
                     }
+                    
+                    self.sortWordBooksBySchedule()
                 }
             }
         }
@@ -179,6 +181,17 @@ extension TodaySelectionModal {
         func dateText(of wordBook: WordBook) -> String {
             let dayGap = wordBook.dayFromToday
             return dayGap == 0 ? "今日" : "\(dayGap)日前"
+        }
+        
+        func sortWordBooksBySchedule() {
+            wordBooks.sort(by: { book1, book2 in
+                if schedules[book1.id, default: .none] != .none
+                    && schedules[book2.id, default: .none] == .none {
+                    return true
+                } else {
+                    return false
+                }
+            })
         }
     }
 }

--- a/JWords/iOSView/Today/TodaySelectionModal.swift
+++ b/JWords/iOSView/Today/TodaySelectionModal.swift
@@ -10,25 +10,44 @@ import SwiftUI
 struct TodaySelectionModal: View {
     
     @ObservedObject private var viewModel: ViewModel
+    @Environment(\.dismiss) private var dismiss
+    @State private var showProgressView: Bool = false
     
     init(_ dependency: Dependency) {
         self.viewModel = ViewModel(dependency)
     }
     
     var body: some View {
-        VStack {
-            Text("학습 혹은 복습할 단어장을 골라주세요.")
-            ScrollView {
-                VStack(spacing: 8) {
-                    ForEach(viewModel.wordBooks, id: \.id) { wordBook in
-                        CheckableCell(wordBook: wordBook, viewModel: viewModel)
+        ZStack {
+            if showProgressView {
+                ProgressView()
+                    .scaleEffect(5)
+            }
+            VStack {
+                Text("학습 혹은 복습할 단어장을 골라주세요.")
+                ScrollView {
+                    VStack(spacing: 8) {
+                        ForEach(viewModel.wordBooks, id: \.id) { wordBook in
+                            CheckableCell(wordBook: wordBook, viewModel: viewModel)
+                        }
                     }
                 }
+                HStack {
+                    Button("취소") { dismiss() }
+                    Spacer()
+                    Button("확인") {
+                        showProgressView = true
+                        viewModel.updateToday {
+                            showProgressView = false
+                            dismiss()
+                        }
+                    }
+                }
+                .padding()
             }
+            .padding(10)
         }
-        .padding(10)
         .onAppear { viewModel.fetchTodays() }
-        .onDisappear { viewModel.updateToday() }
     }
 }
 

--- a/JWords/iOSView/Today/TodayView.swift
+++ b/JWords/iOSView/Today/TodayView.swift
@@ -112,6 +112,7 @@ extension TodayView {
                     self.reviewWordBooks = self.wordBooks.filter {
                         todayBooks.reviewIDs.contains($0.id) && !todayBooks.reviewedIDs.contains($0.id)
                     }
+                    self.fetchOnlyFailWords()
                 }
             }
         }


### PR DESCRIPTION
# 오늘 학습/복습할 단어들을 Firebase에 저장함.
임시로 Memory에 저장했던 Today를 Firebase로 옮김
앱 종료 이후에 다시 시작해도 그대로 오늘 단어들이 유지됨
![투데이파이어베이스](https://user-images.githubusercontent.com/70995840/198171812-16aad625-cb26-4674-a845-3d8d1f9348db.gif)

# 학습, 복습 단어장을 선택하는 Modal에서 기존에 선택한 단어장들이 위로 오도록 정렬함
정해진 일정대로 공부하는 단어장이 아닌 단어장 (ex. 학원 숙제)등을 쉽게 선택해서 제거할 수 있음.
![군군빼고](https://user-images.githubusercontent.com/70995840/198172966-44a67051-91f4-42bf-8d49-b41ad88f6e4c.gif)

# 학습, 복습 단어장을 선택하는 Modal에서 선택된 단어장을 변경할 때 Firebase에 업로드한 후에 Modal이 닫히도록 함
Firebase에 업로드하기 전에 Modal이 닫히면 TodayView에서 선택된 단어장을 fetch해올 때 변경 내용이 fetch되지 않을 수 있음.
![프로그래스만들었음](https://user-images.githubusercontent.com/70995840/198172977-22220851-062d-4dc4-970a-572d90cd305a.gif)
