### PR TITLE
[Feature] Add Functions in MacAddWordView

### DIFF
--- a/JWords/macView/MacAddWordView.swift
+++ b/JWords/macView/MacAddWordView.swift
@@ -197,7 +197,7 @@ extension MacAddWordView {
                     Text(viewModel.samples.isEmpty ? "검색결과 없음" : "미선택")
                         .tag(nil as String?)
                     ForEach(viewModel.samples, id: \.id) { example in
-                        Text("뜻: \(example.meaningText)\n가나: \(example.ganaText)\n한자: \(example.kanjiText)")
+                        Text("뜻: \(example.meaningText)\t가나: \(example.ganaText)\t한자: \(example.kanjiText)")
                             .tag(example.id as String?)
                     }
                 }

--- a/JWords/macView/MacAddWordView.swift
+++ b/JWords/macView/MacAddWordView.swift
@@ -78,6 +78,7 @@ extension MacAddWordView {
                 .onChange(of: viewModel.kanjiText) { viewModel.autoConvert($0) }
                 .onChange(of: viewModel.kanjiText) { moveCursorToGanaWhenTap($0) }
                 .onChange(of: viewModel.ganaText) { viewModel.trimPastedText($0) }
+                .onChange(of: viewModel.ganaText) { moveCursorToMeaningWhenTap($0) }
             }
         }
         
@@ -94,6 +95,14 @@ extension MacAddWordView {
             if last == "\t" {
                 viewModel.kanjiText.removeLast()
                 editFocus = .gana
+            }
+        }
+        
+        private func moveCursorToMeaningWhenTap(_ text: String) {
+            guard let last = text.last else { return }
+            if last == "\t" {
+                viewModel.ganaText.removeLast()
+                editFocus = .meaning
             }
         }
     }

--- a/JWords/macView/MacAddWordView.swift
+++ b/JWords/macView/MacAddWordView.swift
@@ -266,6 +266,7 @@ extension MacAddWordView {
                     Text("저장")
                 }
                 .disabled(viewModel.isSaveButtonUnable)
+                .keyboardShortcut(.return, modifiers: [.command])
             }
         }
     }

--- a/JWords/macView/MacAddWordView.swift
+++ b/JWords/macView/MacAddWordView.swift
@@ -70,7 +70,10 @@ extension MacAddWordView {
                             .focused($editFocus, equals: .gana)
                         ImageInputView(inputType: .gana)
                     }
-                    SaveButton { editFocus = .meaning }
+                    SaveButton {
+                        viewModel.saveWord()
+                        editFocus = .meaning
+                    }
                 }
                 .padding(.top, 50)
                 .onAppear { viewModel.getWordBooks() }
@@ -269,7 +272,6 @@ extension MacAddWordView {
                 ProgressView()
             } else {
                 Button {
-                    viewModel.saveWord()
                     saveButtonTapped()
                 } label: {
                     Text("저장")

--- a/JWords/macView/MacAddWordView.swift
+++ b/JWords/macView/MacAddWordView.swift
@@ -272,7 +272,7 @@ extension MacAddWordView {
                     Text("저장")
                 }
                 .disabled(viewModel.isSaveButtonUnable)
-                .keyboardShortcut(.return, modifiers: [.command])
+                .keyboardShortcut(.return, modifiers: [.control])
             }
         }
     }

--- a/JWords/macView/MacAddWordView.swift
+++ b/JWords/macView/MacAddWordView.swift
@@ -70,7 +70,7 @@ extension MacAddWordView {
                             .focused($editFocus, equals: .kanji)
                         ImageInputView(inputType: .kanji)
                     }
-                    SaveButton()
+                    SaveButton { editFocus = .meaning }
                 }
                 .padding(.top, 50)
                 .onAppear { viewModel.getWordBooks() }
@@ -96,7 +96,6 @@ extension MacAddWordView {
                 editFocus = .kanji
             }
         }
-
     }
 }
 
@@ -250,6 +249,11 @@ extension MacAddWordView {
     
     struct SaveButton: View {
         @EnvironmentObject private var viewModel: ViewModel
+        private let saveButtonTapped: () -> Void
+        
+        init(saveButtonTapped: @escaping () -> Void) {
+            self.saveButtonTapped = saveButtonTapped
+        }
         
         var body: some View {
             if viewModel.isUploading {
@@ -257,6 +261,7 @@ extension MacAddWordView {
             } else {
                 Button {
                     viewModel.saveWord()
+                    saveButtonTapped()
                 } label: {
                     Text("저장")
                 }

--- a/JWords/macView/MacAddWordView.swift
+++ b/JWords/macView/MacAddWordView.swift
@@ -61,39 +61,39 @@ extension MacAddWordView {
                     }
                     .padding(.bottom)
                     VStack {
-                        TextInputView(inputType: .gana)
-                            .focused($editFocus, equals: .gana)
-                        ImageInputView(inputType: .gana)
-                    }
-                    VStack {
                         TextInputView(inputType: .kanji)
                             .focused($editFocus, equals: .kanji)
                         ImageInputView(inputType: .kanji)
+                    }
+                    VStack {
+                        TextInputView(inputType: .gana)
+                            .focused($editFocus, equals: .gana)
+                        ImageInputView(inputType: .gana)
                     }
                     SaveButton { editFocus = .meaning }
                 }
                 .padding(.top, 50)
                 .onAppear { viewModel.getWordBooks() }
-                .onChange(of: viewModel.meaningText) { moveCursorToGanaWhenTap($0) }
-                .onChange(of: viewModel.ganaText) { moveCursorToKanjiWhenTap($0) }
-                .onChange(of: viewModel.ganaText) { viewModel.trimPastedText($0) }
+                .onChange(of: viewModel.meaningText) { moveCursorToKanjiWhenTap($0) }
                 .onChange(of: viewModel.kanjiText) { viewModel.autoConvert($0) }
-            }
-        }
-        
-        private func moveCursorToGanaWhenTap(_ text: String) {
-            guard let last = text.last else { return }
-            if last == "\t" {
-                viewModel.meaningText.removeLast()
-                editFocus = .gana
+                .onChange(of: viewModel.kanjiText) { moveCursorToGanaWhenTap($0) }
+                .onChange(of: viewModel.ganaText) { viewModel.trimPastedText($0) }
             }
         }
         
         private func moveCursorToKanjiWhenTap(_ text: String) {
             guard let last = text.last else { return }
             if last == "\t" {
-                viewModel.ganaText.removeLast()
+                viewModel.meaningText.removeLast()
                 editFocus = .kanji
+            }
+        }
+        
+        private func moveCursorToGanaWhenTap(_ text: String) {
+            guard let last = text.last else { return }
+            if last == "\t" {
+                viewModel.kanjiText.removeLast()
+                editFocus = .gana
             }
         }
     }

--- a/JWords/macView/MacAddWordView.swift
+++ b/JWords/macView/MacAddWordView.swift
@@ -462,8 +462,16 @@ extension MacAddWordView {
                 if let error = error { print(error); return }
                 guard let examples = examples else { print("examples are nil"); return }
                 // example의 이미지는 View에 보여줄 수 없으므로 일단 image 있는 것은 필터링
-                self?.samples = examples.filter({ !$0.hasImage })
-                if !examples.isEmpty { self?.selectedSampleID = examples[0].id }
+                self?.samples = examples
+                                .filter({ !$0.hasImage })
+                                .sorted { ex1, ex2 in
+                                    if !ex1.kanjiText.isEmpty && ex2.kanjiText.isEmpty {
+                                        return true
+                                    } else {
+                                        return false
+                                    }
+                                }
+                if !examples.isEmpty { self?.selectedSampleID = self?.samples[0].id }
             }
         }
         

--- a/JWords/macView/MacAddWordView.swift
+++ b/JWords/macView/MacAddWordView.swift
@@ -77,35 +77,30 @@ extension MacAddWordView {
                 }
                 .padding(.top, 50)
                 .onAppear { viewModel.getWordBooks() }
-                .onChange(of: viewModel.meaningText) { moveCursorToKanjiWhenTap($0) }
+                .onChange(of: viewModel.meaningText) { moveCursorWhenTab($0) }
                 .onChange(of: viewModel.kanjiText) { viewModel.autoConvert($0) }
-                .onChange(of: viewModel.kanjiText) { moveCursorToGanaWhenTap($0) }
+                .onChange(of: viewModel.kanjiText) { moveCursorWhenTab($0) }
                 .onChange(of: viewModel.ganaText) { viewModel.trimPastedText($0) }
-                .onChange(of: viewModel.ganaText) { moveCursorToMeaningWhenTap($0) }
+                .onChange(of: viewModel.ganaText) { moveCursorWhenTab($0) }
             }
         }
         
-        private func moveCursorToKanjiWhenTap(_ text: String) {
-            guard let last = text.last else { return }
-            if last == "\t" {
+        private func moveCursorWhenTab(_ text: String) {
+            guard let last = text.last, last == "\t" else { return }
+            guard let nowCursor = editFocus else { return }
+            switch nowCursor {
+            case .meaning:
                 viewModel.meaningText.removeLast()
                 editFocus = .kanji
-            }
-        }
-        
-        private func moveCursorToGanaWhenTap(_ text: String) {
-            guard let last = text.last else { return }
-            if last == "\t" {
+                return
+            case .kanji:
                 viewModel.kanjiText.removeLast()
                 editFocus = .gana
-            }
-        }
-        
-        private func moveCursorToMeaningWhenTap(_ text: String) {
-            guard let last = text.last else { return }
-            if last == "\t" {
+                return
+            case .gana:
                 viewModel.ganaText.removeLast()
                 editFocus = .meaning
+                return
             }
         }
     }


### PR DESCRIPTION
# 단어 저장되면 커서가 다시 뜻 TextEditor로 이동하도록 함.
## 캡쳐
![커서 맨 위로 자동으로 감](https://user-images.githubusercontent.com/70995840/198213134-f72f5400-5548-472b-89b5-f61e885c8fb5.gif)

## 코드
하위 View에 closure 전달
```swift
SaveButton {
    viewModel.saveWord()
    editFocus = .meaning
}
```
```swift
struct SaveButton: View {
    @EnvironmentObject private var viewModel: ViewModel
    private let saveButtonTapped: () -> Void
    
    init(saveButtonTapped: @escaping () -> Void) {
        self.saveButtonTapped = saveButtonTapped
    }
    
    var body: some View {
        if viewModel.isUploading {
            ProgressView()
        } else {
            Button {
                saveButtonTapped()
            } label: {
                Text("저장")
            }
            .disabled(viewModel.isSaveButtonUnable)
            .keyboardShortcut(.return, modifiers: [.control])
        }
    }
}
```

# 한자와 가나 입력 위치를 변경
한자를 먼저 입력하는 경우가 많았음.
![image](https://user-images.githubusercontent.com/70995840/198212842-1eba9057-30b0-4bfb-a5d9-f8f796e1dcd6.png)

# 저장 버튼에 단축키 적용함
## 구현
![단축키로 저장](https://user-images.githubusercontent.com/70995840/198213149-3e933aef-39a9-481d-8394-5937ef0dd9bf.gif)
## 코드
```swift
Button {
    saveButtonTapped()
} label: {
    Text("저장")
}
.disabled(viewModel.isSaveButtonUnable)
.keyboardShortcut(.return, modifiers: [.control])
```

# 가나 TextEditor에서 tab을 누르면 뜻 TextEditor로 이동하도록 함
## 구현
기존에는 마지막 TextEditor에서 tab을 눌러도 다른 TextEditor로 이동할 수 없었음
![탭하면 뜻으로](https://user-images.githubusercontent.com/70995840/198213217-0eef09f1-1aac-4cba-9710-557ed2a923e7.gif)
## 코드
```swift
private func moveCursorWhenTab(_ text: String) {
    guard let last = text.last, last == "\t" else { return }
    guard let nowCursor = editFocus else { return }
    switch nowCursor {
    case .meaning:
        viewModel.meaningText.removeLast()
        editFocus = .kanji
        return
    case .kanji:
        viewModel.kanjiText.removeLast()
        editFocus = .gana
        return
    case .gana:
        viewModel.ganaText.removeLast()
        editFocus = .meaning
        return
    }
}
```

# 한자가 있는 단어가 앞으로 오도록 sample을 정렬함
## 구현
### before
예전에 DB에 한자를 구분해서 저장하지 않았을 때의 sample이 (한자와 가나가 같이 가나에 저장된) 가장 위에 검색되는 경우가 많았음.
![image](https://user-images.githubusercontent.com/70995840/198215677-40978df8-303f-4b8a-b37e-75d3922af419.png)
### after
한자가 있는 sample이 가장 위로 오도록 정렬함
![image](https://user-images.githubusercontent.com/70995840/198213324-0922cd39-339d-44bf-806a-000eedd05c0e.png)
## 코드
```swift
func getExamples() {
    sampleService.getSamples(meaningText) { [weak self] examples, error in
        if let error = error { print(error); return }
        guard let examples = examples else { print("examples are nil"); return }
        // example의 이미지는 View에 보여줄 수 없으므로 일단 image 있는 것은 필터링
        self?.samples = examples
                        .filter({ !$0.hasImage })
                        .sorted { ex1, ex2 in
                            if !ex1.kanjiText.isEmpty && ex2.kanjiText.isEmpty {
                                return true
                            } else {
                                return false
                            }
                        }
        if !examples.isEmpty { self?.selectedSampleID = self?.samples[0].id }
    }
}
```
# MacOS를 Ventura로 업데이트하니까 Picker에 줄바꿈(\n)이 안되어서 \t으로 변경함
## before
![image](https://user-images.githubusercontent.com/70995840/198213645-0de765dc-475e-4b5e-b6ae-f1a2ee577f3c.png)
## after
![image](https://user-images.githubusercontent.com/70995840/198213360-f23e979e-6354-406f-9cab-d062943fc3b2.png)
