### PR TITLE
[Fix] Selection Mode Debugging

### DIFF
--- a/JWords/iOSView/Study/StudyView.swift
+++ b/JWords/iOSView/Study/StudyView.swift
@@ -96,6 +96,7 @@ struct StudyView: View {
                     Button("랜덤") {
                         viewModel.shuffleWords()
                     }
+                    .disabled(viewModel.isSelectionMode)
                     Button("설정") {
                         showSideBar = true
                     }

--- a/JWords/iOSView/Study/StudyView.swift
+++ b/JWords/iOSView/Study/StudyView.swift
@@ -153,8 +153,10 @@ extension StudyView {
                     }
                     .pickerStyle(.segmented)
                     .padding()
-                    Toggle("선택 모드", isOn: $viewModel.isSelectionMode)
-                        .padding()
+                    if viewModel.wordBook != nil {
+                        Toggle("선택 모드", isOn: $viewModel.isSelectionMode)
+                            .padding()
+                    }
                     Spacer()
                 }
                 .frame(width: Constants.Size.deviceWidth * 0.7)


### PR DESCRIPTION
# 틀린 단어 모아보기에서는 선택 모드로 진입할 수 없도록 함
wordBook이 nil인 경우 crash가 남.
![image](https://user-images.githubusercontent.com/70995840/198457349-713c9c72-46eb-4f86-8ded-25a3e8b92d7e.png)
# 선택 모드에서는 Random 버튼 비활성화
![image](https://user-images.githubusercontent.com/70995840/198457509-443046dc-8eaa-4654-b728-9d48eecd1195.png)
