### PR TITLE
[JWS-30] 단어부터 입력하게 순서 바꾸기

### DIFF
--- a/JWords.xcodeproj/project.pbxproj
+++ b/JWords.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		06BC606D297E9A7500AA67E6 /* FrontType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06BC606C297E9A7500AA67E6 /* FrontType.swift */; };
 		06BC608A29A0928600AA67E6 /* View+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06BC608929A0928600AA67E6 /* View+Extension.swift */; };
 		06BC608C29A09FC000AA67E6 /* ViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06BC608B29A09FC000AA67E6 /* ViewModifier.swift */; };
+		06BC609A29AEF04600AA67E6 /* MacAddWordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06BC609929AEF04600AA67E6 /* MacAddWordView.swift */; };
 		06CB256F28EC58EE00A7FC76 /* HomeViewModelTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06CB256E28EC58EE00A7FC76 /* HomeViewModelTest.swift */; };
 		06CEF2472866F1C800A620CC /* JWordsApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06CEF2462866F1C800A620CC /* JWordsApp.swift */; };
 		06CEF2492866F1C800A620CC /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06CEF2482866F1C800A620CC /* ContentView.swift */; };
@@ -50,7 +51,6 @@
 		5A67DC2D2869470C00AC156C /* WordCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A67DC2C2869470C00AC156C /* WordCell.swift */; };
 		5A67DC312869529700AC156C /* MacHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A67DC302869529700AC156C /* MacHomeView.swift */; };
 		5A67DC332869565A00AC156C /* MacAddBookView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A67DC322869565A00AC156C /* MacAddBookView.swift */; };
-		5A67DC352869566600AC156C /* MacAddWordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A67DC342869566600AC156C /* MacAddWordView.swift */; };
 		5A6BA59C28E53BAE004B04FC /* MockSample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A6BA59B28E53BAE004B04FC /* MockSample.swift */; };
 		5A6BBF7A28E68A15003D9A4D /* StudyViewModelTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A6BBF7928E68A15003D9A4D /* StudyViewModelTest.swift */; };
 		5A6BBF7C28E68E10003D9A4D /* MockWord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A6BBF7B28E68E10003D9A4D /* MockWord.swift */; };
@@ -127,6 +127,7 @@
 		06BC606C297E9A7500AA67E6 /* FrontType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrontType.swift; sourceTree = "<group>"; };
 		06BC608929A0928600AA67E6 /* View+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extension.swift"; sourceTree = "<group>"; };
 		06BC608B29A09FC000AA67E6 /* ViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModifier.swift; sourceTree = "<group>"; };
+		06BC609929AEF04600AA67E6 /* MacAddWordView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MacAddWordView.swift; sourceTree = "<group>"; };
 		06CB256E28EC58EE00A7FC76 /* HomeViewModelTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModelTest.swift; sourceTree = "<group>"; };
 		06CEF2432866F1C800A620CC /* JWords.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JWords.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		06CEF2462866F1C800A620CC /* JWordsApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWordsApp.swift; sourceTree = "<group>"; };
@@ -157,7 +158,6 @@
 		5A67DC2C2869470C00AC156C /* WordCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordCell.swift; sourceTree = "<group>"; };
 		5A67DC302869529700AC156C /* MacHomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacHomeView.swift; sourceTree = "<group>"; };
 		5A67DC322869565A00AC156C /* MacAddBookView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacAddBookView.swift; sourceTree = "<group>"; };
-		5A67DC342869566600AC156C /* MacAddWordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacAddWordView.swift; sourceTree = "<group>"; };
 		5A6BA59B28E53BAE004B04FC /* MockSample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSample.swift; sourceTree = "<group>"; };
 		5A6BBF7928E68A15003D9A4D /* StudyViewModelTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyViewModelTest.swift; sourceTree = "<group>"; };
 		5A6BBF7B28E68E10003D9A4D /* MockWord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWord.swift; sourceTree = "<group>"; };
@@ -446,8 +446,8 @@
 			isa = PBXGroup;
 			children = (
 				5A67DC302869529700AC156C /* MacHomeView.swift */,
+				06BC609929AEF04600AA67E6 /* MacAddWordView.swift */,
 				5A67DC322869565A00AC156C /* MacAddBookView.swift */,
-				5A67DC342869566600AC156C /* MacAddWordView.swift */,
 			);
 			path = MacView;
 			sourceTree = "<group>";
@@ -712,6 +712,7 @@
 				06BC606A297B939500AA67E6 /* LazyView.swift in Sources */,
 				5AE7A76D28D981D9005E12B6 /* Date+Extension.swift in Sources */,
 				06BC608A29A0928600AA67E6 /* View+Extension.swift in Sources */,
+				06BC609A29AEF04600AA67E6 /* MacAddWordView.swift in Sources */,
 				5AE1DB1C28C5D640006DB89C /* WordBookService.swift in Sources */,
 				068D4CFC28B2189300F44F6E /* WordMoveView.swift in Sources */,
 				5A67DC27286944FF00AC156C /* Size.swift in Sources */,
@@ -725,7 +726,6 @@
 				5AB28AA428F6B94200FF80CE /* KanaConverter.swift in Sources */,
 				5A67DC332869565A00AC156C /* MacAddBookView.swift in Sources */,
 				5A616D9F28C05A0E0013B5AE /* Database.swift in Sources */,
-				5A67DC352869566600AC156C /* MacAddWordView.swift in Sources */,
 				5A67DC23286943A900AC156C /* HomeCell.swift in Sources */,
 				06A564D6289E9C5100DBC2E0 /* WordInputView.swift in Sources */,
 				5A67DC2A286946F800AC156C /* StudyView.swift in Sources */,

--- a/JWords/DataService/SampleService.swift
+++ b/JWords/DataService/SampleService.swift
@@ -10,6 +10,7 @@ import Foundation
 protocol SampleService {
     func saveSample(wordInput: WordInput)
     func getSamples(_ query: String, completionHandler: @escaping CompletionWithData<[Sample]>)
+    func getSamplesByMeaning(_ query: String, completionHandler: @escaping CompletionWithData<[Sample]>)
     func addOneToUsed(of sample: Sample)
 }
 
@@ -27,6 +28,10 @@ class SampleServiceImpl: SampleService {
     
     func getSamples(_ query: String, completionHandler: @escaping ([Sample]?, Error?) -> Void) {
         db.fetchSample(query, completionHandler: completionHandler)
+    }
+    
+    func getSamplesByMeaning(_ query: String, completionHandler: @escaping ([Sample]?, Error?) -> Void) {
+        db.fetchSampleByMeaning(query, completionHandler: completionHandler)
     }
     
     func addOneToUsed(of sample: Sample) {

--- a/JWords/macView/MacAddWordView.swift
+++ b/JWords/macView/MacAddWordView.swift
@@ -436,7 +436,7 @@ extension MacAddWordView {
         }
         
         func getExamples() {
-            sampleService.getSamples(meaningText) { [weak self] examples, error in
+            sampleService.getSamples(kanjiText) { [weak self] examples, error in
                 if let error = error { print(error); return }
                 guard let examples = examples else { print("examples are nil"); return }
                 // example의 이미지는 View에 보여줄 수 없으므로 일단 image 있는 것은 필터링

--- a/JWords/macView/MacAddWordView.swift
+++ b/JWords/macView/MacAddWordView.swift
@@ -107,7 +107,7 @@ extension MacAddWordView {
             } label: {
                 Text("찾기")
             }
-            .disabled(viewModel.meaningText.isEmpty)
+            .disabled(viewModel.kanjiText.isEmpty)
             .keyboardShortcut("f", modifiers: [.command])
         }
         

--- a/JWords/macView/MacAddWordView.swift
+++ b/JWords/macView/MacAddWordView.swift
@@ -18,7 +18,7 @@ typealias PasteBoardType = NSPasteboard
 struct MacAddWordView: View {
     // MARK: Enum
     enum InputType: Hashable, CaseIterable {
-        case meaning, kanji, gana
+        case kanji, meaning, gana
         
         var description: String {
             switch self {

--- a/JWords/macView/MacAddWordView.swift
+++ b/JWords/macView/MacAddWordView.swift
@@ -18,7 +18,7 @@ typealias PasteBoardType = NSPasteboard
 struct MacAddWordView: View {
     // MARK: Enum
     enum InputType: Hashable, CaseIterable {
-        case kanji, meaning, gana
+        case kanji, gana, meaning
         
         var description: String {
             switch self {
@@ -130,14 +130,14 @@ extension MacAddWordView {
                     .font(.system(size: 30))
                     .frame(height: Constants.Size.deviceHeight / 8)
                     .padding(.horizontal)
-                if inputType == .meaning {
+                if inputType == .kanji {
                     HStack {
                         overlapCheckButton
                         searchExampleButton
                         samplePicker
                     }
                     .padding(.horizontal)
-                } else if inputType == .kanji {
+                } else if inputType == .gana {
                     Toggle("한자 -> 가나 자동 변환", isOn: $viewModel.isAutoConvert)
                 }
             }


### PR DESCRIPTION
https://steadyslower.atlassian.net/browse/JWS-30?atlOrigin=eyJpIjoiNDY0YjFlMzk3YzE1NDA1OThmOWVlMzgxOTMwYzE0YjEiLCJwIjoiaiJ9

Sample을 검색할 때 한자를 사용하도록 함.

<img width="642" alt="image" src="https://user-images.githubusercontent.com/70995840/222033986-e4400bad-3d5b-43a2-b913-24387ebcde92.png">
