### PR TITLE
[JWS-9] 저장할 때 공백 lstrip, rstrip

### DIFF
--- a/JWords.xcodeproj/project.pbxproj
+++ b/JWords.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0688A1D429B3345E0057B2DB /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0688A1D329B3345E0057B2DB /* String+Extension.swift */; };
 		068D4CFC28B2189300F44F6E /* WordMoveView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 068D4CFB28B2189300F44F6E /* WordMoveView.swift */; };
 		0697715328CCA71700569280 /* WordInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0697715228CCA71700569280 /* WordInput.swift */; };
 		0697715528CCCF1300569280 /* MacAddBookViewModelTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0697715428CCCF1200569280 /* MacAddBookViewModelTest.swift */; };
@@ -116,6 +117,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0688A1D329B3345E0057B2DB /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
 		068D4CFB28B2189300F44F6E /* WordMoveView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordMoveView.swift; sourceTree = "<group>"; };
 		0697715228CCA71700569280 /* WordInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordInput.swift; sourceTree = "<group>"; };
 		0697715428CCCF1200569280 /* MacAddBookViewModelTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacAddBookViewModelTest.swift; sourceTree = "<group>"; };
@@ -381,6 +383,7 @@
 				5A5C468728D98894000E212B /* Calendar+Extension.swift */,
 				06BC608929A0928600AA67E6 /* View+Extension.swift */,
 				06BC608B29A09FC000AA67E6 /* ViewModifier.swift */,
+				0688A1D329B3345E0057B2DB /* String+Extension.swift */,
 			);
 			path = Helper;
 			sourceTree = "<group>";
@@ -713,6 +716,7 @@
 				5AE7A76D28D981D9005E12B6 /* Date+Extension.swift in Sources */,
 				06BC608A29A0928600AA67E6 /* View+Extension.swift in Sources */,
 				06BC609A29AEF04600AA67E6 /* MacAddWordView.swift in Sources */,
+				0688A1D429B3345E0057B2DB /* String+Extension.swift in Sources */,
 				5AE1DB1C28C5D640006DB89C /* WordBookService.swift in Sources */,
 				068D4CFC28B2189300F44F6E /* WordMoveView.swift in Sources */,
 				5A67DC27286944FF00AC156C /* Size.swift in Sources */,

--- a/JWords/Helper/String+Extension.swift
+++ b/JWords/Helper/String+Extension.swift
@@ -1,0 +1,38 @@
+//
+//  String+Extension.swift
+//  JWords
+//
+//  Created by JW Moon on 2023/03/04.
+//
+
+import Foundation
+
+extension String {
+    
+    static let whitespaceAndNewlineCharacters: [Character] = [" ", "\n", "\t"]
+
+    func rStrip(_ charactors: [Character] = String.whitespaceAndNewlineCharacters) -> String {
+        var s = self
+        guard s.contains(where: { charactors.contains($0) }) else { return self }
+        while let last = s.last,
+              charactors.contains(last) {
+            s = String(s.dropLast())
+            print("rstrip")
+        }
+        print(s)
+        return s
+        
+    }
+    
+    func lStrip(_ charactors: [Character] = String.whitespaceAndNewlineCharacters) -> String {
+        var s = self
+        guard s.contains(where: { charactors.contains($0) }) else { return self }
+        while let first = s.first,
+              charactors.contains(first) {
+            s = String(s.dropFirst())
+            print("lstrip")
+        }
+        print(s)
+        return s
+    }
+}

--- a/JWords/macView/MacAddWordView.swift
+++ b/JWords/macView/MacAddWordView.swift
@@ -354,6 +354,7 @@ extension MacAddWordView {
         }
         
         func saveWord() {
+            trimTexts()
             isUploading = true
             guard let wordBookID = selectedBookID else {
                 // TODO: handle error
@@ -471,6 +472,15 @@ extension MacAddWordView {
                 guard let count = count else { print("No count in wordbook: \(wordBook.id)"); return }
                 self?.wordCount = count
             }
+        }
+        
+        private func trimTexts() {
+            meaningText = meaningText.lStrip()
+            meaningText = meaningText.rStrip()
+            kanjiText = kanjiText.lStrip()
+            kanjiText = kanjiText.rStrip()
+            ganaText = ganaText.lStrip()
+            ganaText = ganaText.rStrip()
         }
         
         private func clearInputs() {


### PR DESCRIPTION
https://steadyslower.atlassian.net/browse/JWS-9?atlOrigin=eyJpIjoiYzg4ODc2M2YxOWJmNGU1NmFkZmJhNmZjYTIyMWZkOWIiLCJwIjoiaiJ9

입력한 텍스트의 좌우에 있는 " ", "\n", "\t"는 삭제