### PR TITLE
[JWS-57] 후리가나 로직 만들기

### DIFF
--- a/JWords.xcodeproj/project.pbxproj
+++ b/JWords.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		0622726929F3B69100EEAD50 /* ImageClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0622726829F3B69100EEAD50 /* ImageClient.swift */; };
 		0622727329FC9C3400EEAD50 /* WordBookPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0622727229FC9C3400EEAD50 /* WordBookPicker.swift */; };
 		0622727629FCEE1500EEAD50 /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 0622727529FCEE1500EEAD50 /* ComposableArchitecture */; };
+		0622727829FCFAD700EEAD50 /* HuriganaConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0622727729FCFAD700EEAD50 /* HuriganaConverter.swift */; };
+		0622727A29FCFC2600EEAD50 /* Character+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0622727929FCFC2600EEAD50 /* Character+Extension.swift */; };
 		0624735D29C6D8580076DBE4 /* InputType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0624735C29C6D8580076DBE4 /* InputType.swift */; };
 		0647529F29B45AB90047E84A /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0647529E29B45AB90047E84A /* GoogleService-Info.plist */; };
 		067840EB29C55E350019ABA8 /* AddWordRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 067840EA29C55E350019ABA8 /* AddWordRepository.swift */; };
@@ -140,6 +142,8 @@
 /* Begin PBXFileReference section */
 		0622726829F3B69100EEAD50 /* ImageClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageClient.swift; sourceTree = "<group>"; };
 		0622727229FC9C3400EEAD50 /* WordBookPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = WordBookPicker.swift; path = JWords/macView/Components/WordBookPicker.swift; sourceTree = SOURCE_ROOT; };
+		0622727729FCFAD700EEAD50 /* HuriganaConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuriganaConverter.swift; sourceTree = "<group>"; };
+		0622727929FCFC2600EEAD50 /* Character+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Character+Extension.swift"; sourceTree = "<group>"; };
 		0624735C29C6D8580076DBE4 /* InputType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputType.swift; sourceTree = "<group>"; };
 		0647529E29B45AB90047E84A /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		067840EA29C55E350019ABA8 /* AddWordRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddWordRepository.swift; sourceTree = "<group>"; };
@@ -442,6 +446,7 @@
 			children = (
 				5A5FF631286AD79E000150A7 /* ImageCompressor.swift */,
 				5AB28AA328F6B94200FF80CE /* KanaConverter.swift */,
+				0622727729FCFAD700EEAD50 /* HuriganaConverter.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -455,6 +460,7 @@
 				06BC608929A0928600AA67E6 /* View+Extension.swift */,
 				06BC608B29A09FC000AA67E6 /* ViewModifier.swift */,
 				0688A1D329B3345E0057B2DB /* String+Extension.swift */,
+				0622727929FCFC2600EEAD50 /* Character+Extension.swift */,
 			);
 			path = Helper;
 			sourceTree = "<group>";
@@ -814,6 +820,7 @@
 				0622727329FC9C3400EEAD50 /* WordBookPicker.swift in Sources */,
 				06BC609A29AEF04600AA67E6 /* MacAddWordView.swift in Sources */,
 				5A8B698A29F234B000B5A02E /* TodayClient.swift in Sources */,
+				0622727A29FCFC2600EEAD50 /* Character+Extension.swift in Sources */,
 				0688A1D429B3345E0057B2DB /* String+Extension.swift in Sources */,
 				5A7C6FD929FB6D1700DD84A4 /* PasteBoardClient.swift in Sources */,
 				5AE1DB1C28C5D640006DB89C /* WordBookService.swift in Sources */,
@@ -826,6 +833,7 @@
 				5A67DC2D2869470C00AC156C /* StudyCell.swift in Sources */,
 				5A7D079F29F8CC090022D0D7 /* BookInputView.swift in Sources */,
 				5A5C468828D98894000E212B /* Calendar+Extension.swift in Sources */,
+				0622727829FCFAD700EEAD50 /* HuriganaConverter.swift in Sources */,
 				06E4066229C5578D0055B104 /* RepositoryManager.swift in Sources */,
 				5AB28AA428F6B94200FF80CE /* KanaConverter.swift in Sources */,
 				5A67DC332869565A00AC156C /* MacAddBookView.swift in Sources */,

--- a/JWords.xcodeproj/project.pbxproj
+++ b/JWords.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		0622727629FCEE1500EEAD50 /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 0622727529FCEE1500EEAD50 /* ComposableArchitecture */; };
 		0622727829FCFAD700EEAD50 /* HuriganaConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0622727729FCFAD700EEAD50 /* HuriganaConverter.swift */; };
 		0622727A29FCFC2600EEAD50 /* Character+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0622727929FCFC2600EEAD50 /* Character+Extension.swift */; };
+		0622727C29FDEADC00EEAD50 /* HuriganaTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0622727B29FDEADC00EEAD50 /* HuriganaTestView.swift */; };
 		0624735D29C6D8580076DBE4 /* InputType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0624735C29C6D8580076DBE4 /* InputType.swift */; };
 		0647529F29B45AB90047E84A /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0647529E29B45AB90047E84A /* GoogleService-Info.plist */; };
 		067840EB29C55E350019ABA8 /* AddWordRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 067840EA29C55E350019ABA8 /* AddWordRepository.swift */; };
@@ -144,6 +145,7 @@
 		0622727229FC9C3400EEAD50 /* WordBookPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = WordBookPicker.swift; path = JWords/macView/Components/WordBookPicker.swift; sourceTree = SOURCE_ROOT; };
 		0622727729FCFAD700EEAD50 /* HuriganaConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuriganaConverter.swift; sourceTree = "<group>"; };
 		0622727929FCFC2600EEAD50 /* Character+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Character+Extension.swift"; sourceTree = "<group>"; };
+		0622727B29FDEADC00EEAD50 /* HuriganaTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = HuriganaTestView.swift; path = JWords/macView/HuriganaTestView.swift; sourceTree = SOURCE_ROOT; };
 		0624735C29C6D8580076DBE4 /* InputType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputType.swift; sourceTree = "<group>"; };
 		0647529E29B45AB90047E84A /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		067840EA29C55E350019ABA8 /* AddWordRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddWordRepository.swift; sourceTree = "<group>"; };
@@ -540,6 +542,7 @@
 				5A67DC302869529700AC156C /* MacAppView.swift */,
 				06BC609929AEF04600AA67E6 /* MacAddWordView.swift */,
 				5A67DC322869565A00AC156C /* MacAddBookView.swift */,
+				0622727B29FDEADC00EEAD50 /* HuriganaTestView.swift */,
 			);
 			path = MacView;
 			sourceTree = "<group>";
@@ -826,6 +829,7 @@
 				5AE1DB1C28C5D640006DB89C /* WordBookService.swift in Sources */,
 				068D4CFC28B2189300F44F6E /* WordMoveView.swift in Sources */,
 				5A67DC27286944FF00AC156C /* Size.swift in Sources */,
+				0622727C29FDEADC00EEAD50 /* HuriganaTestView.swift in Sources */,
 				5A5740A828BDA8900080A2E2 /* Sample.swift in Sources */,
 				5A653FEB2907C1C800E3466E /* TodaySchedule.swift in Sources */,
 				5A1FADFB28A1FC87000ACBD2 /* DataResettingScript.swift in Sources */,

--- a/JWords/Helper/Character+Extension.swift
+++ b/JWords/Helper/Character+Extension.swift
@@ -1,0 +1,17 @@
+//
+//  Character+Extension.swift
+//  JWords
+//
+//  Created by JW Moon on 2023/04/29.
+//
+
+extension Character {
+    var isKanji: Bool {
+        if let scalar = self.unicodeScalars.first,
+           scalar.properties.isUnifiedIdeograph {
+            return true
+        } else {
+            return false
+        }
+    }
+}

--- a/JWords/Helper/String+Extension.swift
+++ b/JWords/Helper/String+Extension.swift
@@ -54,4 +54,13 @@ extension String {
             return false
         }
     }
+    
+    var isKatakana: Bool {
+        let katakanaCharacterSet = CharacterSet(charactersIn: "\u{30A0}"..."\u{30FF}")
+        if self.unicodeScalars.allSatisfy({ katakanaCharacterSet.contains($0) }) {
+            return true
+        } else {
+            return false
+        }
+    }
 }

--- a/JWords/Helper/String+Extension.swift
+++ b/JWords/Helper/String+Extension.swift
@@ -43,4 +43,15 @@ extension String {
         print(s)
         return s
     }
+    
+    var isPunctuation: Bool {
+        guard self.count == 1 else { return false }
+        let char = Character(self)
+        if char.unicodeScalars.count == 1,
+           CharacterSet.punctuationCharacters.contains(char.unicodeScalars.first!) {
+            return true
+        } else {
+            return false
+        }
+    }
 }

--- a/JWords/Utilities/HuriganaConverter.swift
+++ b/JWords/Utilities/HuriganaConverter.swift
@@ -1,0 +1,16 @@
+//
+//  HuriganaConverter.swift
+//  JWords
+//
+//  Created by JW Moon on 2023/04/29.
+//
+
+import Foundation
+
+class HuriganaConverter {
+    
+    static let shared = HuriganaConverter()
+    
+    
+    
+}

--- a/JWords/Utilities/HuriganaConverter.swift
+++ b/JWords/Utilities/HuriganaConverter.swift
@@ -40,6 +40,7 @@ class HuriganaConverter {
             // 토큰이 가나이거나, 구두점이거나, 빈칸이면 그냥 더하기
             if token == gana
                 || token.isPunctuation
+                || token.isKatakana
                 || token == " "
                 || gana == ""
             {

--- a/JWords/Utilities/HuriganaConverter.swift
+++ b/JWords/Utilities/HuriganaConverter.swift
@@ -25,17 +25,26 @@ class HuriganaConverter {
                                     kCFStringTokenizerUnitWordBoundary, // 단어 단위로 쪼갠다
                                     Locale(identifier: "ja") as CFLocale) // 언어 설정 (일본어)
         
+        // 하나씩 토큰을 넘기면서
         while !CFStringTokenizerAdvanceToNextToken(tokenizer).isEmpty {
             
+            // 원래 토큰에 해당하는 String을 잘라서 가져온다.
             let tokenRange = CFStringTokenizerGetCurrentTokenRange(tokenizer)
             let tokenStart = trimmed.index(trimmed.startIndex, offsetBy: tokenRange.location)
             let tokenEnd = trimmed.index(tokenStart, offsetBy: tokenRange.length)
             let token = String(trimmed[tokenStart..<tokenEnd])
             
+            // 해당 토큰을 가나로 변환
             let gana = tokenizer.letter(to: kCFStringTransformLatinHiragana)
             
-            if token == gana || token.isPunctuation || token == " " || gana == "" {
+            // 토큰이 가나이거나, 구두점이거나, 빈칸이면 그냥 더하기
+            if token == gana
+                || token.isPunctuation
+                || token == " "
+                || gana == ""
+            {
                 result.append(token)
+            // 한자면 []안에 더하기
             } else {
                 result.append("\(token)[\(gana)]")
             }

--- a/JWords/Utilities/HuriganaConverter.swift
+++ b/JWords/Utilities/HuriganaConverter.swift
@@ -11,6 +11,38 @@ class HuriganaConverter {
     
     static let shared = HuriganaConverter()
     
-    
+    func convert(_ input: String) -> String {
+        var result = ""
+        
+        // 주어진 String의 공백과 \n을 모두 없앤다.
+        let trimmed: String = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        // CFStringTokenizer 객체를 만든다.
+        let tokenizer: CFStringTokenizer =
+            CFStringTokenizerCreate(kCFAllocatorDefault, // 메모리 할당하는 객체
+                                    trimmed as CFString, // token으로 쪼갤 CFString
+                                    CFRangeMake(0, trimmed.utf16.count), // token으로 쪼갤 CFString의 range (= 전체)
+                                    kCFStringTokenizerUnitWordBoundary, // 단어 단위로 쪼갠다
+                                    Locale(identifier: "ja") as CFLocale) // 언어 설정 (일본어)
+        
+        while !CFStringTokenizerAdvanceToNextToken(tokenizer).isEmpty {
+            
+            let tokenRange = CFStringTokenizerGetCurrentTokenRange(tokenizer)
+            let tokenStart = trimmed.index(trimmed.startIndex, offsetBy: tokenRange.location)
+            let tokenEnd = trimmed.index(tokenStart, offsetBy: tokenRange.length)
+            let token = String(trimmed[tokenStart..<tokenEnd])
+            
+            let gana = tokenizer.letter(to: kCFStringTransformLatinHiragana)
+            
+            if token == gana || token.isPunctuation || token == " " || gana == "" {
+                result.append(token)
+            } else {
+                result.append("\(token)[\(gana)]")
+            }
+        }
+        
+        return result
+    }
     
 }
+

--- a/JWords/Utilities/KanaConverter.swift
+++ b/JWords/Utilities/KanaConverter.swift
@@ -10,7 +10,7 @@
 import Foundation
 
 // CFStringTokenizer: 연속된 String을 Token (단어, 문장) 단위로 쪼개주는 객체
-private extension CFStringTokenizer {
+extension CFStringTokenizer {
     
     // CFStringTokenizer 안에 있는 CFString을 가지고 string으로 바꾸어주는 computed property
         // kCFStringTransformLatinHiragana과 kCFStringTransformLatinKatakana는 CFString 타입이지만 실제로 데이터를 담고 있는 것은 아니고
@@ -29,7 +29,7 @@ private extension CFStringTokenizer {
     }
 
     // 토큰 하나를 gana string으로 하나로 바꾸어 주는 함수
-    private func letter(to transform: CFString) -> String {
+    func letter(to transform: CFString) -> String {
         
         // 현재 Token을 복사해오는데 Lantin Transction으로 가져온다. (여기서 한자가 Latin Transcription으로 바뀜)
             // 그리고 나서 NSString -> NSMutableString으로 바꾼다 (Latin을 gana로 바꾸기 위해서 mutable로)

--- a/JWords/macView/HuriganaTestView.swift
+++ b/JWords/macView/HuriganaTestView.swift
@@ -1,0 +1,28 @@
+//
+//  HuriganaTestView.swift
+//  JWords
+//
+//  Created by JW Moon on 2023/04/30.
+//
+
+import SwiftUI
+
+struct HuriganaTestView: View {
+    
+    @State var text: String = ""
+    @State var hurigana: String = ""
+    
+    var body: some View {
+        VStack {
+            Text(hurigana)
+            TextField("", text: $text)
+                .onChange(of: text) { hurigana = HuriganaConverter.shared.convert($0) }
+        }
+    }
+}
+
+struct HuriganaTestView_Previews: PreviewProvider {
+    static var previews: some View {
+        HuriganaTestView()
+    }
+}

--- a/JWords/macView/MacAppView.swift
+++ b/JWords/macView/MacAppView.swift
@@ -60,6 +60,11 @@ struct MacAppView: View {
                 } label: {
                     Text("add word")
                 }
+                NavigationLink {
+                    HuriganaTestView()
+                } label: {
+                    Text("hurigana test")
+                }
             }
         }
         .navigationViewStyle(.automatic)


### PR DESCRIPTION
https://steadyslower.atlassian.net/browse/JWS-57?atlOrigin=eyJpIjoiNjMwYzhmMTlhODg3NGU4YmI0ZGYyOTk5OWE2N2I2MTEiLCJwIjoiaiJ9

```swift
func convert(_ input: String) -> String {
    var result = ""
    
    // 주어진 String의 공백과 \n을 모두 없앤다.
    let trimmed: String = input.trimmingCharacters(in: .whitespacesAndNewlines)
    
    // CFStringTokenizer 객체를 만든다.
    let tokenizer: CFStringTokenizer =
        CFStringTokenizerCreate(kCFAllocatorDefault, // 메모리 할당하는 객체
                                trimmed as CFString, // token으로 쪼갤 CFString
                                CFRangeMake(0, trimmed.utf16.count), // token으로 쪼갤 CFString의 range (= 전체)
                                kCFStringTokenizerUnitWordBoundary, // 단어 단위로 쪼갠다
                                Locale(identifier: "ja") as CFLocale) // 언어 설정 (일본어)
    
    // 하나씩 토큰을 넘기면서
    while !CFStringTokenizerAdvanceToNextToken(tokenizer).isEmpty {
        
        // 원래 토큰에 해당하는 String을 잘라서 가져온다.
        let tokenRange = CFStringTokenizerGetCurrentTokenRange(tokenizer)
        let tokenStart = trimmed.index(trimmed.startIndex, offsetBy: tokenRange.location)
        let tokenEnd = trimmed.index(tokenStart, offsetBy: tokenRange.length)
        let token = String(trimmed[tokenStart..<tokenEnd])
        
        // 해당 토큰을 가나로 변환
        let gana = tokenizer.letter(to: kCFStringTransformLatinHiragana)
        
        // 토큰이 가나이거나, 구두점이거나, 빈칸이면 그냥 더하기
        if token == gana
            || token.isPunctuation
            || token.isKatakana
            || token == " "
            || gana == ""
        {
            result.append(token)
        // 한자면 []안에 더하기
        } else {
            result.append("\(token)[\(gana)]")
        }
    }
    
    return result
}
```